### PR TITLE
fix(examples/nextjs): type errors

### DIFF
--- a/examples/nextjs/package.json
+++ b/examples/nextjs/package.json
@@ -2,7 +2,8 @@
   "name": "@bento-editor/example-nextjs",
   "version": "0.0.5",
   "scripts": {
-    "dev": "next dev"
+    "dev": "next dev",
+    "build": "next build"
   },
   "dependencies": {
     "@bento-editor/core": "*",

--- a/packages/element-list/src/list/attributes/index.ts
+++ b/packages/element-list/src/list/attributes/index.ts
@@ -1,12 +1,12 @@
 import { Element } from '@bento-editor/core';
 
 export type Attributes = {
-  listStyleType: 'disc' | 'circle';
+  listStyleType?: 'disc' | 'circle';
 };
 
 const attributes: Element<Attributes>['attributes'] = {
   defaultValue: {
-    listStyleType: 'disc'
-  }
+    listStyleType: 'disc',
+  },
 };
 export default attributes;

--- a/packages/element-paragraph/src/attributes/index.ts
+++ b/packages/element-paragraph/src/attributes/index.ts
@@ -1,12 +1,8 @@
 import { Element } from '@bento-editor/core';
 
-export type Attributes = {
-  foo: 'hoge' | 'bar';
-};
+export type Attributes = {};
 
 const attributes: Element<Attributes>['attributes'] = {
-  defaultValue: {
-    foo: 'hoge'
-  }
+  defaultValue: {},
 };
 export default attributes;


### PR DESCRIPTION
## Summary

`next build` が通るように型エラーを修正