### PR TITLE
fix: send button type to button and quit form tag of the element-link

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "bento-editor",
-  "version": "0.0.7",
+  "version": "0.0.9",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "bento-editor",
-      "version": "0.0.7",
+      "version": "0.0.9",
       "license": "MIT",
       "workspaces": [
         "apps/*",
@@ -29,7 +29,7 @@
     },
     "apps/website": {
       "name": "@bento-editor/website",
-      "version": "0.0.7",
+      "version": "0.0.9",
       "dependencies": {
         "@docusaurus/core": "^2.0.1",
         "@docusaurus/preset-classic": "^2.0.1",
@@ -630,7 +630,7 @@
     },
     "examples/nextjs": {
       "name": "@bento-editor/example-nextjs",
-      "version": "0.0.7",
+      "version": "0.0.9",
       "dependencies": {
         "@bento-editor/core": "*",
         "@bento-editor/element-callout": "*",
@@ -658,7 +658,7 @@
     },
     "examples/react": {
       "name": "@bento-editor/example-react",
-      "version": "0.0.7",
+      "version": "0.0.9",
       "dependencies": {
         "@bento-editor/core": "*",
         "@bento-editor/element-callout": "*",
@@ -17828,7 +17828,7 @@
     },
     "packages/core": {
       "name": "@bento-editor/core",
-      "version": "0.0.7",
+      "version": "0.0.9",
       "license": "MIT",
       "dependencies": {
         "@rmwc/switch": "^8.0.1",
@@ -17875,7 +17875,7 @@
     },
     "packages/element-callout": {
       "name": "@bento-editor/element-callout",
-      "version": "0.0.7",
+      "version": "0.0.9",
       "license": "MIT",
       "devDependencies": {
         "@types/jest": "^28.1.1",
@@ -17887,13 +17887,13 @@
         "vite": "^3.1.8"
       },
       "peerDependencies": {
-        "@bento-editor/core": "0.0.7",
+        "@bento-editor/core": "0.0.9",
         "@vanilla-extract/css": "^1.7.2"
       }
     },
     "packages/element-divider": {
       "name": "@bento-editor/element-divider",
-      "version": "0.0.7",
+      "version": "0.0.9",
       "license": "MIT",
       "devDependencies": {
         "@types/jest": "^28.1.1",
@@ -17905,12 +17905,12 @@
         "vite": "^3.1.8"
       },
       "peerDependencies": {
-        "@bento-editor/core": "0.0.7"
+        "@bento-editor/core": "0.0.9"
       }
     },
     "packages/element-embed": {
       "name": "@bento-editor/element-embed",
-      "version": "0.0.7",
+      "version": "0.0.9",
       "license": "MIT",
       "devDependencies": {
         "@types/jest": "^28.1.1",
@@ -17922,13 +17922,13 @@
         "vite": "^3.1.8"
       },
       "peerDependencies": {
-        "@bento-editor/core": "0.0.7",
+        "@bento-editor/core": "0.0.9",
         "@vanilla-extract/css": "^1.7.2"
       }
     },
     "packages/element-heading": {
       "name": "@bento-editor/element-heading",
-      "version": "0.0.7",
+      "version": "0.0.9",
       "license": "MIT",
       "devDependencies": {
         "@types/jest": "^28.1.1",
@@ -17940,12 +17940,12 @@
         "vite": "^3.1.8"
       },
       "peerDependencies": {
-        "@bento-editor/core": "0.0.7"
+        "@bento-editor/core": "0.0.9"
       }
     },
     "packages/element-link": {
       "name": "@bento-editor/element-link",
-      "version": "0.0.7",
+      "version": "0.0.9",
       "license": "MIT",
       "devDependencies": {
         "@types/jest": "^28.1.1",
@@ -17957,13 +17957,13 @@
         "vite": "^3.1.8"
       },
       "peerDependencies": {
-        "@bento-editor/core": "0.0.7",
+        "@bento-editor/core": "0.0.9",
         "@vanilla-extract/css": "^1.7.2"
       }
     },
     "packages/element-list": {
       "name": "@bento-editor/element-list",
-      "version": "0.0.7",
+      "version": "0.0.9",
       "license": "MIT",
       "devDependencies": {
         "@types/jest": "^28.1.1",
@@ -17975,13 +17975,13 @@
         "vite": "^3.1.8"
       },
       "peerDependencies": {
-        "@bento-editor/core": "0.0.7",
+        "@bento-editor/core": "0.0.9",
         "@vanilla-extract/css": "^1.7.2"
       }
     },
     "packages/element-note": {
       "name": "@bento-editor/element-note",
-      "version": "0.0.7",
+      "version": "0.0.9",
       "license": "MIT",
       "devDependencies": {
         "@types/jest": "^28.1.1",
@@ -17993,13 +17993,13 @@
         "vite": "^3.1.8"
       },
       "peerDependencies": {
-        "@bento-editor/core": "0.0.7",
+        "@bento-editor/core": "0.0.9",
         "@vanilla-extract/css": "^1.7.2"
       }
     },
     "packages/element-paragraph": {
       "name": "@bento-editor/element-paragraph",
-      "version": "0.0.7",
+      "version": "0.0.9",
       "license": "MIT",
       "devDependencies": {
         "@types/jest": "^28.1.1",
@@ -18011,12 +18011,12 @@
         "vite": "^3.1.8"
       },
       "peerDependencies": {
-        "@bento-editor/core": "0.0.7"
+        "@bento-editor/core": "0.0.9"
       }
     },
     "packages/element-quote": {
       "name": "@bento-editor/element-quote",
-      "version": "0.0.7",
+      "version": "0.0.9",
       "license": "MIT",
       "devDependencies": {
         "@types/jest": "^28.1.1",
@@ -18028,12 +18028,12 @@
         "vite": "^3.1.8"
       },
       "peerDependencies": {
-        "@bento-editor/core": "0.0.7"
+        "@bento-editor/core": "0.0.9"
       }
     },
     "packages/element-toggle": {
       "name": "@bento-editor/element-toggle",
-      "version": "0.0.7",
+      "version": "0.0.9",
       "license": "MIT",
       "devDependencies": {
         "@types/jest": "^28.1.1",
@@ -18045,13 +18045,13 @@
         "vite": "^3.1.8"
       },
       "peerDependencies": {
-        "@bento-editor/core": "0.0.7",
+        "@bento-editor/core": "0.0.9",
         "@vanilla-extract/css": "^1.7.2"
       }
     },
     "packages/text-emoji": {
       "name": "@bento-editor/text-emoji",
-      "version": "0.0.7",
+      "version": "0.0.9",
       "license": "MIT",
       "dependencies": {
         "@emoji-mart/data": "^1.0.6",
@@ -18068,7 +18068,7 @@
         "vite": "^3.1.0"
       },
       "peerDependencies": {
-        "@bento-editor/core": "0.0.7",
+        "@bento-editor/core": "0.0.9",
         "@vanilla-extract/css": "^1.7.2"
       }
     },
@@ -18945,7 +18945,7 @@
     },
     "packages/text-format": {
       "name": "@bento-editor/text-format",
-      "version": "0.0.7",
+      "version": "0.0.9",
       "license": "MIT",
       "dependencies": {
         "react-colorful": "^5.6.1"
@@ -18961,7 +18961,7 @@
         "vite": "^3.1.8"
       },
       "peerDependencies": {
-        "@bento-editor/core": "0.0.7",
+        "@bento-editor/core": "0.0.9",
         "@vanilla-extract/css": "^1.7.2"
       }
     }

--- a/packages/core/src/components/button/index.tsx
+++ b/packages/core/src/components/button/index.tsx
@@ -1,5 +1,11 @@
 import classnames from 'classnames';
-import React, { forwardRef, useCallback } from 'react';
+import {
+  forwardRef,
+  MouseEvent,
+  MouseEventHandler,
+  ReactNode,
+  useCallback,
+} from 'react';
 import { styles } from './index.css';
 
 export const BUTTON_RADIUS = {
@@ -13,14 +19,14 @@ export type ButtonRadius = typeof BUTTON_RADIUS[keyof typeof BUTTON_RADIUS];
 export type ButtonProps = {
   radius?: ButtonRadius;
   disabled?: boolean;
-  onClick: React.MouseEventHandler;
-  children: React.ReactNode;
+  onClick: MouseEventHandler;
+  children: ReactNode;
 };
 
 export const Button = forwardRef<HTMLButtonElement, ButtonProps>(
   ({ radius = BUTTON_RADIUS.NONE, onClick, children, disabled }, ref) => {
     const handleClick = useCallback(
-      (e: React.MouseEvent) => {
+      (e: MouseEvent) => {
         onClick(e);
       },
       [onClick]

--- a/packages/core/src/components/button/index.tsx
+++ b/packages/core/src/components/button/index.tsx
@@ -32,6 +32,7 @@ export const Button: React.FC<ButtonProps> = ({
 
   return (
     <button
+      type="button"
       className={classnames({
         [styles.root]: true,
         [styles.rootRadiusSmall]: radius === BUTTON_RADIUS.SMALL,

--- a/packages/core/src/components/button/index.tsx
+++ b/packages/core/src/components/button/index.tsx
@@ -1,11 +1,5 @@
 import classnames from 'classnames';
-import {
-  forwardRef,
-  MouseEvent,
-  MouseEventHandler,
-  ReactNode,
-  useCallback,
-} from 'react';
+import { forwardRef, useCallback } from 'react';
 import { styles } from './index.css';
 
 export const BUTTON_RADIUS = {
@@ -19,14 +13,14 @@ export type ButtonRadius = typeof BUTTON_RADIUS[keyof typeof BUTTON_RADIUS];
 export type ButtonProps = {
   radius?: ButtonRadius;
   disabled?: boolean;
-  onClick: MouseEventHandler;
-  children: ReactNode;
+  onClick: React.MouseEventHandler;
+  children: React.ReactNode;
 };
 
 export const Button = forwardRef<HTMLButtonElement, ButtonProps>(
   ({ radius = BUTTON_RADIUS.NONE, onClick, children, disabled }, ref) => {
     const handleClick = useCallback(
-      (e: MouseEvent) => {
+      (e: React.MouseEvent) => {
         onClick(e);
       },
       [onClick]

--- a/packages/core/src/components/button/index.tsx
+++ b/packages/core/src/components/button/index.tsx
@@ -1,5 +1,5 @@
 import classnames from 'classnames';
-import { useCallback } from 'react';
+import React, { forwardRef, useCallback } from 'react';
 import { styles } from './index.css';
 
 export const BUTTON_RADIUS = {
@@ -17,34 +17,32 @@ export type ButtonProps = {
   children: React.ReactNode;
 };
 
-export const Button: React.FC<ButtonProps> = ({
-  radius = BUTTON_RADIUS.NONE,
-  onClick,
-  children,
-  disabled,
-}) => {
-  const handleClick = useCallback(
-    (e: React.MouseEvent) => {
-      onClick(e);
-    },
-    [onClick]
-  );
+export const Button = forwardRef<HTMLButtonElement, ButtonProps>(
+  ({ radius = BUTTON_RADIUS.NONE, onClick, children, disabled }, ref) => {
+    const handleClick = useCallback(
+      (e: React.MouseEvent) => {
+        onClick(e);
+      },
+      [onClick]
+    );
 
-  return (
-    <button
-      type="button"
-      className={classnames({
-        [styles.root]: true,
-        [styles.rootRadiusSmall]: radius === BUTTON_RADIUS.SMALL,
-        [styles.rootRadiusMedium]: radius === BUTTON_RADIUS.MEDIUM,
-        [styles.rootRadiusFull]: radius === BUTTON_RADIUS.FULL,
-        [styles.disabled]: !!disabled,
-      })}
-      onClick={handleClick}
-      disabled={disabled}
-    >
-      <div className={styles.bg} />
-      <div className={styles.container}>{children}</div>
-    </button>
-  );
-};
+    return (
+      <button
+        ref={ref}
+        type="button"
+        className={classnames({
+          [styles.root]: true,
+          [styles.rootRadiusSmall]: radius === BUTTON_RADIUS.SMALL,
+          [styles.rootRadiusMedium]: radius === BUTTON_RADIUS.MEDIUM,
+          [styles.rootRadiusFull]: radius === BUTTON_RADIUS.FULL,
+          [styles.disabled]: !!disabled,
+        })}
+        onClick={handleClick}
+        disabled={disabled}
+      >
+        <div className={styles.bg} />
+        <div className={styles.container}>{children}</div>
+      </button>
+    );
+  }
+);

--- a/packages/core/src/portals/modal/index.tsx
+++ b/packages/core/src/portals/modal/index.tsx
@@ -24,7 +24,9 @@ export const Modal: React.FC<ModalProps> = ({
     <Portal target={TARGET.MODAL}>
       <div className={styles.root}>
         <div>
-          <button onClick={handleCloseClick}>close</button>
+          <button type="button" onClick={handleCloseClick}>
+            close
+          </button>
         </div>
         <div>{children}</div>
       </div>

--- a/packages/core/src/toolbar/index.tsx
+++ b/packages/core/src/toolbar/index.tsx
@@ -21,7 +21,7 @@ export const ButtonBox: React.FC<ButtonBoxProps> = ({
   name,
 }) => {
   return (
-    <button className={styles.buttonBox} onClick={onClick}>
+    <button type="button" className={styles.buttonBox} onClick={onClick}>
       <span className={styles.featureIcon}>{featureIcon}</span>
       {name && <span>{name}</span>}
       <span className={styles.dropDownIcon}>
@@ -169,7 +169,11 @@ export const Toolbar: React.FC<ToolbarProps> = () => {
                 )
             )}
             <li className={styles.item} ref={popoverMore.targetRef}>
-              <button className={styles.moreButton} onClick={handleMoreClick}>
+              <button
+                type="button"
+                className={styles.moreButton}
+                onClick={handleMoreClick}
+              >
                 <svg viewBox="0 0 20 20">
                   <path
                     d="M10.5 16C10.0833 16 9.72933 15.854 9.438 15.562C9.146 15.2707 9 14.9167 9 14.5C9 14.0833 9.146 13.7293 9.438 13.438C9.72933 13.146 10.0833 13 10.5 13C10.9167 13 11.2707 13.146 11.562 13.438C11.854 13.7293 12 14.0833 12 14.5C12 14.9167 11.854 15.2707 11.562 15.562C11.2707 15.854 10.9167 16 10.5 16ZM10.5 11.5C10.0833 11.5 9.72933 11.354 9.438 11.062C9.146 10.7707 9 10.4167 9 10C9 9.58333 9.146 9.22933 9.438 8.938C9.72933 8.646 10.0833 8.5 10.5 8.5C10.9167 8.5 11.2707 8.646 11.562 8.938C11.854 9.22933 12 9.58333 12 10C12 10.4167 11.854 10.7707 11.562 11.062C11.2707 11.354 10.9167 11.5 10.5 11.5ZM10.5 7C10.0833 7 9.72933 6.854 9.438 6.562C9.146 6.27067 9 5.91667 9 5.5C9 5.08333 9.146 4.72933 9.438 4.438C9.72933 4.146 10.0833 4 10.5 4C10.9167 4 11.2707 4.146 11.562 4.438C11.854 4.72933 12 5.08333 12 5.5C12 5.91667 11.854 6.27067 11.562 6.562C11.2707 6.854 10.9167 7 10.5 7Z"

--- a/packages/core/src/toolmenu/index.tsx
+++ b/packages/core/src/toolmenu/index.tsx
@@ -34,7 +34,7 @@ export const Toolmenu: React.FC<ToolmenuProps> = ({ path, onDone }) => {
       <div>
         <ul>
           <li>
-            <button className={styles.button} onClick={handleDeleteClick}>
+            <button type="button" className={styles.button} onClick={handleDeleteClick}>
               <div className={styles.buttonBG} />
               <div className={styles.buttonContainer}>
                 <div className={styles.buttonIcon}>
@@ -45,7 +45,7 @@ export const Toolmenu: React.FC<ToolmenuProps> = ({ path, onDone }) => {
             </button>
           </li>
           <li>
-            <button className={styles.button} onClick={handleCopyClick}>
+            <button type="button" className={styles.button} onClick={handleCopyClick}>
               <div className={styles.buttonBG} />
               <div className={styles.buttonContainer}>
                 <div className={styles.buttonIcon}>

--- a/packages/element-embed/src/components/form/index.tsx
+++ b/packages/element-embed/src/components/form/index.tsx
@@ -3,7 +3,6 @@ import { useRef, useEffect } from 'react';
 import { styles } from './index.css';
 
 type FormProps = {
-  handleFormSubmit: React.FormEventHandler;
   handleTextboxChange: React.ChangeEventHandler;
   handleButtonClick: React.MouseEventHandler;
   labelValue: string;
@@ -21,7 +20,6 @@ export type FormErrors = {
 };
 
 export const Form: React.FC<FormProps> = ({
-  handleFormSubmit,
   handleTextboxChange,
   handleButtonClick,
   labelValue,
@@ -32,20 +30,20 @@ export const Form: React.FC<FormProps> = ({
   errors,
   embedTitle,
 }) => {
-  const formRef = useRef<HTMLFormElement | null>(null);
+  const buttonRef = useRef<HTMLButtonElement | null>(null);
 
   // The submit event will be called for the second time.
   // Emitting this for doing setNodes without re-rendering recursively.
   useEffect(() => {
     if (embedTitle != null && embedTitle !== '') {
-      formRef.current?.dispatchEvent(
-        new Event('submit', { cancelable: true, bubbles: true })
+      buttonRef.current?.dispatchEvent(
+        new Event('click', { cancelable: true, bubbles: true })
       );
     }
-  }, [formRef, embedTitle]);
+  }, [buttonRef, embedTitle]);
 
   return (
-    <form ref={formRef} className={styles.root} onSubmit={handleFormSubmit}>
+    <div className={styles.root}>
       <div className={styles.field}>
         <Textbox
           value={textboxValue}
@@ -63,10 +61,11 @@ export const Form: React.FC<FormProps> = ({
           onClick={handleButtonClick}
           disabled={buttonDisabled}
           radius="full"
+          ref={buttonRef}
         >
           {buttonValue}
         </Button>
       </div>
-    </form>
+    </div>
   );
 };

--- a/packages/element-embed/src/components/form/index.tsx
+++ b/packages/element-embed/src/components/form/index.tsx
@@ -1,17 +1,16 @@
 import { Button, Textbox } from '@bento-editor/core';
-import { useRef, useEffect } from 'react';
 import { styles } from './index.css';
 
 type FormProps = {
   handleTextboxChange: React.ChangeEventHandler;
   handleButtonClick: React.MouseEventHandler;
+  buttonRef: React.MutableRefObject<HTMLButtonElement | null>;
   labelValue: string;
   buttonValue: string;
   textboxValue?: string;
   placeholder?: string;
   buttonDisabled?: boolean;
   errors?: FormErrors | null;
-  embedTitle?: string | null;
 };
 
 export type FormErrors = {
@@ -22,26 +21,14 @@ export type FormErrors = {
 export const Form: React.FC<FormProps> = ({
   handleTextboxChange,
   handleButtonClick,
+  buttonRef,
   labelValue,
   buttonValue,
   textboxValue,
   placeholder,
   buttonDisabled,
   errors,
-  embedTitle,
 }) => {
-  const buttonRef = useRef<HTMLButtonElement | null>(null);
-
-  // The submit event will be called for the second time.
-  // Emitting this for doing setNodes without re-rendering recursively.
-  useEffect(() => {
-    if (embedTitle != null && embedTitle !== '') {
-      buttonRef.current?.dispatchEvent(
-        new Event('click', { cancelable: true, bubbles: true })
-      );
-    }
-  }, [buttonRef, embedTitle]);
-
   return (
     <div className={styles.root}>
       <div className={styles.field}>

--- a/packages/element-embed/src/editable/index.tsx
+++ b/packages/element-embed/src/editable/index.tsx
@@ -74,22 +74,6 @@ var id='embedly-platform', n = 'script';
       }
     }, [typeof window.embedly, embedlyRef, href]);
 
-    const submittedForm = useCallback(() => {
-      if (newHref !== undefined && isUrl(newHref) && embedTitle !== undefined) {
-        setNodes({
-          attributes: {
-            href: newHref,
-            title: embedTitle,
-          },
-        });
-      } else {
-        setErrors({
-          reason: 'Invalid url.',
-          message: '有効なURLを入力してください。',
-        });
-      }
-    }, [setNodes, newHref, embedTitle]);
-
     const handleTextboxChange = useCallback(
       (event: React.ChangeEvent<HTMLInputElement>) => {
         setNewHref(event.target.value);
@@ -104,10 +88,37 @@ var id='embedly-platform', n = 'script';
     const handleFormButtonClick = useCallback(
       (event: React.MouseEvent<HTMLButtonElement>) => {
         event.stopPropagation();
-        submittedForm();
+        if (
+          newHref !== undefined &&
+          isUrl(newHref) &&
+          embedTitle !== undefined
+        ) {
+          setNodes({
+            attributes: {
+              href: newHref,
+              title: embedTitle,
+            },
+          });
+        } else {
+          setErrors({
+            reason: 'Invalid url.',
+            message: '有効なURLを入力してください。',
+          });
+        }
       },
-      [submittedForm]
+      [setNodes, newHref, embedTitle]
     );
+
+    const buttonRef = useRef<HTMLButtonElement | null>(null);
+    // The click event will be called for the second time.
+    // Emitting this for doing setNodes without re-rendering recursively.
+    useEffect(() => {
+      if (embedTitle != null && embedTitle !== '') {
+        buttonRef.current?.dispatchEvent(
+          new Event('click', { cancelable: true, bubbles: true })
+        );
+      }
+    }, [buttonRef, embedTitle]);
 
     return (
       <ElementContainer {...props}>
@@ -126,7 +137,7 @@ var id='embedly-platform', n = 'script';
               placeholder={placeholder}
               buttonDisabled={newHref == null || newHref === ''}
               errors={errors}
-              embedTitle={embedTitle}
+              buttonRef={buttonRef}
             />
           )}
         </div>

--- a/packages/element-embed/src/editable/index.tsx
+++ b/packages/element-embed/src/editable/index.tsx
@@ -74,30 +74,21 @@ var id='embedly-platform', n = 'script';
       }
     }, [typeof window.embedly, embedlyRef, href]);
 
-    const handleFormSubmit = useCallback(
-      (event: React.FormEvent<HTMLFormElement>) => {
-        event.preventDefault();
-
-        if (
-          newHref !== undefined &&
-          isUrl(newHref) &&
-          embedTitle !== undefined
-        ) {
-          setNodes({
-            attributes: {
-              href: newHref,
-              title: embedTitle,
-            },
-          });
-        } else {
-          setErrors({
-            reason: 'Invalid url.',
-            message: '有効なURLを入力してください。',
-          });
-        }
-      },
-      [setNodes, newHref, embedTitle]
-    );
+    const submittedForm = useCallback(() => {
+      if (newHref !== undefined && isUrl(newHref) && embedTitle !== undefined) {
+        setNodes({
+          attributes: {
+            href: newHref,
+            title: embedTitle,
+          },
+        });
+      } else {
+        setErrors({
+          reason: 'Invalid url.',
+          message: '有効なURLを入力してください。',
+        });
+      }
+    }, [setNodes, newHref, embedTitle]);
 
     const handleTextboxChange = useCallback(
       (event: React.ChangeEvent<HTMLInputElement>) => {
@@ -113,8 +104,9 @@ var id='embedly-platform', n = 'script';
     const handleFormButtonClick = useCallback(
       (event: React.MouseEvent<HTMLButtonElement>) => {
         event.stopPropagation();
+        submittedForm();
       },
-      []
+      [submittedForm]
     );
 
     return (
@@ -127,7 +119,6 @@ var id='embedly-platform', n = 'script';
             </div>
           ) : (
             <Form
-              handleFormSubmit={handleFormSubmit}
               handleTextboxChange={handleTextboxChange}
               handleButtonClick={handleFormButtonClick}
               labelValue="PDF、Googleドライブ、Googleマップ、CodePenなどのリンクが使えます"

--- a/packages/element-link/src/components/form/index.tsx
+++ b/packages/element-link/src/components/form/index.tsx
@@ -2,7 +2,6 @@ import { Button, Switch, Textbox } from '@bento-editor/core';
 import { styles } from './index.css';
 
 type FormProps = {
-  handleFormSubmit: React.FormEventHandler;
   handleTextboxChange: React.ChangeEventHandler;
   handleCheckboxChange: React.FormEventHandler;
   handleButtonClick: React.MouseEventHandler;
@@ -22,7 +21,6 @@ export type FormErrors = {
 };
 
 export const Form: React.FC<FormProps> = ({
-  handleFormSubmit,
   handleTextboxChange,
   handleCheckboxChange,
   handleButtonClick,
@@ -36,7 +34,7 @@ export const Form: React.FC<FormProps> = ({
   errors,
 }) => {
   return (
-    <form className={styles.root} onSubmit={handleFormSubmit}>
+    <div className={styles.root}>
       <div className={styles.field}>
         <Textbox
           value={textboxValue}
@@ -62,6 +60,6 @@ export const Form: React.FC<FormProps> = ({
           {buttonValue}
         </Button>
       </div>
-    </form>
+    </div>
   );
 };

--- a/packages/element-link/src/editable/index.tsx
+++ b/packages/element-link/src/editable/index.tsx
@@ -65,36 +65,32 @@ const editable: Element<Attributes>['editable'] = {
       setIsEditing(true);
     }, []);
 
-    const submittedForm = useCallback(() => {
-      if (newHref !== undefined && isUrl(newHref)) {
-        setNodes({
-          attributes: {
-            href: newHref,
-            target: openInNew ? '_blank' : '_self',
-          },
-        });
-      } else {
-        setErrors({
-          reason: 'Invalid url.',
-          message: '有効なURLを入力してください。',
-        });
-      }
-
-      if (isEditing) {
-        setIsEditing(false);
-      }
-
-      if (showEdit) {
-        setShowEdit(false);
-      }
-    }, [setNodes, isEditing, isHovering, newHref, openInNew]);
-
     const handleFormButtonClick = useCallback(
       (event: React.MouseEvent<HTMLButtonElement>) => {
         event.stopPropagation();
-        submittedForm();
+        if (newHref !== undefined && isUrl(newHref)) {
+          setNodes({
+            attributes: {
+              href: newHref,
+              target: openInNew ? '_blank' : '_self',
+            },
+          });
+        } else {
+          setErrors({
+            reason: 'Invalid url.',
+            message: '有効なURLを入力してください。',
+          });
+        }
+
+        if (isEditing) {
+          setIsEditing(false);
+        }
+
+        if (showEdit) {
+          setShowEdit(false);
+        }
       },
-      [submittedForm]
+      [setNodes, isEditing, isHovering, newHref, openInNew]
     );
 
     return (

--- a/packages/element-link/src/editable/index.tsx
+++ b/packages/element-link/src/editable/index.tsx
@@ -47,39 +47,9 @@ const editable: Element<Attributes>['editable'] = {
       setIsHovering(true);
     }, []);
 
-    const handleFormSubmit = useCallback(
-      (event: React.FormEvent<HTMLFormElement>) => {
-        event.preventDefault();
-
-        if (newHref !== undefined && isUrl(newHref)) {
-          setNodes({
-            attributes: {
-              href: newHref,
-              target: openInNew ? '_blank' : '_self',
-            },
-          });
-        } else {
-          setErrors({
-            reason: 'Invalid url.',
-            message: '有効なURLを入力してください。',
-          });
-        }
-
-        if (isEditing) {
-          setIsEditing(false);
-        }
-
-        if (showEdit) {
-          setShowEdit(false);
-        }
-      },
-      [setNodes, isEditing, isHovering, newHref, openInNew]
-    );
-
     const handleTextboxChange = useCallback(
       (event: React.ChangeEvent<HTMLInputElement>) => {
         setNewHref(event.target.value);
-
         if (event.target.checkValidity()) {
           setErrors(null);
         }
@@ -95,11 +65,36 @@ const editable: Element<Attributes>['editable'] = {
       setIsEditing(true);
     }, []);
 
+    const submittedForm = useCallback(() => {
+      if (newHref !== undefined && isUrl(newHref)) {
+        setNodes({
+          attributes: {
+            href: newHref,
+            target: openInNew ? '_blank' : '_self',
+          },
+        });
+      } else {
+        setErrors({
+          reason: 'Invalid url.',
+          message: '有効なURLを入力してください。',
+        });
+      }
+
+      if (isEditing) {
+        setIsEditing(false);
+      }
+
+      if (showEdit) {
+        setShowEdit(false);
+      }
+    }, [setNodes, isEditing, isHovering, newHref, openInNew]);
+
     const handleFormButtonClick = useCallback(
       (event: React.MouseEvent<HTMLButtonElement>) => {
         event.stopPropagation();
+        submittedForm();
       },
-      []
+      [submittedForm]
     );
 
     return (
@@ -130,7 +125,6 @@ const editable: Element<Attributes>['editable'] = {
             </div>
           ) : (
             <Form
-              handleFormSubmit={handleFormSubmit}
               handleTextboxChange={handleTextboxChange}
               handleCheckboxChange={handleCheckboxChange}
               handleButtonClick={handleFormButtonClick}

--- a/packages/element-toggle/src/head/editable/index.tsx
+++ b/packages/element-toggle/src/head/editable/index.tsx
@@ -1,4 +1,9 @@
-import { Element, ElementContainer, helpers, OpenerIcon } from '@bento-editor/core';
+import {
+  Element,
+  ElementContainer,
+  helpers,
+  OpenerIcon,
+} from '@bento-editor/core';
 import { useCallback, useContext } from 'react';
 import { Attributes } from '../attributes';
 import { styles } from './index.css';
@@ -31,7 +36,7 @@ const editable: Element<Attributes>['editable'] = {
       <ElementContainer {...props} utilsPositionY={4}>
         <div className={styles.root}>
           <div className={styles.ctrl} contentEditable={false}>
-            <button className={styles.opener} onClick={handleCtrlClick}>
+            <button type="button" className={styles.opener} onClick={handleCtrlClick}>
               <OpenerIcon isOpened={parentElement.attributes?.isOpen} />
             </button>
           </div>

--- a/packages/text-format/src/components/form/index.tsx
+++ b/packages/text-format/src/components/form/index.tsx
@@ -2,7 +2,6 @@ import { styles } from './index.css';
 import { Button, Switch, Textbox } from '@bento-editor/core';
 
 type FormProps = {
-  handleFormSubmit: React.FormEventHandler;
   handleTextboxChange: React.ChangeEventHandler;
   handleSwitchChange: React.FormEventHandler;
   handleButtonClick: React.MouseEventHandler;
@@ -21,7 +20,6 @@ export type FormErrors = {
 };
 
 export const Form: React.FC<FormProps> = ({
-  handleFormSubmit,
   handleTextboxChange,
   handleSwitchChange,
   handleButtonClick,
@@ -35,7 +33,7 @@ export const Form: React.FC<FormProps> = ({
   errors,
 }) => {
   return (
-    <form onSubmit={handleFormSubmit} className={styles.root}>
+    <div className={styles.root}>
       <div>
         <Textbox
           value={textboxValue}
@@ -61,6 +59,6 @@ export const Form: React.FC<FormProps> = ({
           {buttonValue}
         </Button>
       </div>
-    </form>
+    </div>
   );
 };

--- a/packages/text-format/src/toolbar/index.tsx
+++ b/packages/text-format/src/toolbar/index.tsx
@@ -44,31 +44,26 @@ const toolbar: Text<Attributes>['toolbar'] = {
     const [href, setHref] = useState(attributes.defaultValue.href ?? '');
     const [errors, setErrors] = useState<FormErrors | null>(null);
 
-    const handleFormSubmit = useCallback(
-      (event: React.FormEvent<HTMLFormElement>) => {
-        event.preventDefault();
-
-        if (href !== undefined && isUrl(href)) {
-          helpers.Transforms.setNodes(
-            editor,
-            {
-              attributes: {
-                href,
-                target: openInNew ? '_blank' : '_self',
-              },
+    const submittedForm = useCallback(() => {
+      if (href !== undefined && isUrl(href)) {
+        helpers.Transforms.setNodes(
+          editor,
+          {
+            attributes: {
+              href,
+              target: openInNew ? '_blank' : '_self',
             },
-            { match: (n) => helpers.Text.isText(n), split: true }
-          );
-          popoverLink.close();
-        } else {
-          setErrors({
-            reason: 'Invalid url.',
-            message: '有効なURLを入力してください。',
-          });
-        }
-      },
-      [editor, href, openInNew, popoverLink]
-    );
+          },
+          { match: (n) => helpers.Text.isText(n), split: true }
+        );
+        popoverLink.close();
+      } else {
+        setErrors({
+          reason: 'Invalid url.',
+          message: '有効なURLを入力してください。',
+        });
+      }
+    }, [editor, href, openInNew, popoverLink]);
     const handleFormTextboxChange = useCallback(
       (event: React.ChangeEvent<HTMLInputElement>) => {
         setHref(event.target.value);
@@ -85,8 +80,9 @@ const toolbar: Text<Attributes>['toolbar'] = {
     const handleFormButtonClick = useCallback(
       (event: React.MouseEvent<HTMLButtonElement>) => {
         event.stopPropagation();
+        submittedForm();
       },
-      []
+      [submittedForm]
     );
 
     const popoverColor = usePopover<HTMLLIElement>();
@@ -200,7 +196,6 @@ const toolbar: Text<Attributes>['toolbar'] = {
         </ul>
         <Popover {...popoverLink.bind}>
           <Form
-            handleFormSubmit={handleFormSubmit}
             handleTextboxChange={handleFormTextboxChange}
             handleSwitchChange={handleFormSwitchChange}
             handleButtonClick={handleFormButtonClick}

--- a/packages/text-format/src/toolbar/index.tsx
+++ b/packages/text-format/src/toolbar/index.tsx
@@ -44,26 +44,6 @@ const toolbar: Text<Attributes>['toolbar'] = {
     const [href, setHref] = useState(attributes.defaultValue.href ?? '');
     const [errors, setErrors] = useState<FormErrors | null>(null);
 
-    const submittedForm = useCallback(() => {
-      if (href !== undefined && isUrl(href)) {
-        helpers.Transforms.setNodes(
-          editor,
-          {
-            attributes: {
-              href,
-              target: openInNew ? '_blank' : '_self',
-            },
-          },
-          { match: (n) => helpers.Text.isText(n), split: true }
-        );
-        popoverLink.close();
-      } else {
-        setErrors({
-          reason: 'Invalid url.',
-          message: '有効なURLを入力してください。',
-        });
-      }
-    }, [editor, href, openInNew, popoverLink]);
     const handleFormTextboxChange = useCallback(
       (event: React.ChangeEvent<HTMLInputElement>) => {
         setHref(event.target.value);
@@ -80,9 +60,26 @@ const toolbar: Text<Attributes>['toolbar'] = {
     const handleFormButtonClick = useCallback(
       (event: React.MouseEvent<HTMLButtonElement>) => {
         event.stopPropagation();
-        submittedForm();
+        if (href !== undefined && isUrl(href)) {
+          helpers.Transforms.setNodes(
+            editor,
+            {
+              attributes: {
+                href,
+                target: openInNew ? '_blank' : '_self',
+              },
+            },
+            { match: (n) => helpers.Text.isText(n), split: true }
+          );
+          popoverLink.close();
+        } else {
+          setErrors({
+            reason: 'Invalid url.',
+            message: '有効なURLを入力してください。',
+          });
+        }
       },
-      [submittedForm]
+      [editor, href, openInNew, popoverLink]
     );
 
     const popoverColor = usePopover<HTMLLIElement>();

--- a/packages/text-format/src/toolbar/index.tsx
+++ b/packages/text-format/src/toolbar/index.tsx
@@ -129,7 +129,11 @@ const toolbar: Text<Attributes>['toolbar'] = {
             />
           </li>
           <li>
-            <button className={styles.button} onClick={handleBoldClick}>
+            <button
+              type="button"
+              className={styles.button}
+              onClick={handleBoldClick}
+            >
               <svg viewBox="0 0 20 20">
                 <path
                   d="M6 15V4H10.2696C11.2087 4 12.0031 4.27767 12.6531 4.833C13.3023 5.389 13.627 6.06967 13.627 6.875C13.627 7.403 13.499 7.87167 13.243 8.281C12.9876 8.691 12.6252 9.014 12.1557 9.25V9.354C12.7081 9.53467 13.1534 9.861 13.4917 10.333C13.8306 10.8057 14 11.3407 14 11.938C14 12.8407 13.6648 13.5767 12.9943 14.146C12.3245 14.7153 11.4646 15 10.4148 15H6ZM8.05123 8.5H10.1243C10.5388 8.5 10.891 8.37167 11.1808 8.115C11.4713 7.85767 11.6165 7.54167 11.6165 7.167C11.6165 6.80567 11.4782 6.49667 11.2017 6.24C10.9251 5.98267 10.5866 5.854 10.186 5.854H8.05123V8.5ZM8.05123 13.104H10.3522C10.8356 13.104 11.2226 12.979 11.5131 12.729C11.8029 12.479 11.9478 12.1387 11.9478 11.708C11.9478 11.264 11.7992 10.9133 11.5021 10.656C11.205 10.3993 10.8008 10.271 10.2895 10.271H8.05123V13.104Z"
@@ -139,7 +143,11 @@ const toolbar: Text<Attributes>['toolbar'] = {
             </button>
           </li>
           <li>
-            <button className={styles.button} onClick={handleItalicClick}>
+            <button
+              type="button"
+              className={styles.button}
+              onClick={handleItalicClick}
+            >
               <svg viewBox="0 0 20 20">
                 <path
                   d="M5 16V14H7.375L10.562 6H8V4H15V6H12.729L9.521 14H12V16H5Z"
@@ -150,6 +158,7 @@ const toolbar: Text<Attributes>['toolbar'] = {
           </li>
           <li>
             <button
+              type="button"
               className={styles.button}
               onClick={handleStrikethroughClick}
             >
@@ -162,7 +171,11 @@ const toolbar: Text<Attributes>['toolbar'] = {
             </button>
           </li>
           <li>
-            <button className={styles.button} onClick={handleUnderlineClick}>
+            <button
+              type="button"
+              className={styles.button}
+              onClick={handleUnderlineClick}
+            >
               <svg viewBox="0 0 20 20">
                 <path
                   d="M4 17V15.5H16V17H4ZM10 14C8.69981 14 7.60329 13.566 6.71044 12.698C5.81759 11.83 5.37116 10.764 5.37116 9.5V3H7.42842V9.5C7.42842 10.1947 7.67838 10.785 8.1783 11.271C8.67821 11.757 9.28544 12 10 12C10.7146 12 11.3218 11.757 11.8217 11.271C12.3216 10.785 12.5716 10.1947 12.5716 9.5V3H14.6288V9.5C14.6288 10.764 14.1824 11.83 13.2896 12.698C12.3967 13.566 11.3002 14 10 14Z"


### PR DESCRIPTION
## Summary
- formタグでの実装をやめる
  - form in formが禁止されているので
  - 使う側でformタグでラップされることが想定される
- button type="button"にする
  - formでbento自体がラップされた時に送信用されてしまう



## Reference(s)

