### PR TITLE
fix: vite global constance to wrap json stringify

### DIFF
--- a/packages/core/vite.config.ts
+++ b/packages/core/vite.config.ts
@@ -20,7 +20,7 @@ export default defineConfig({
     },
   },
   define: {
-    VERSION: pkg.version,
+    VERSION: JSON.stringify(pkg.version),
   },
   plugins: [vanillaExtractPlugin(), react()],
 });


### PR DESCRIPTION
Switch to the `Preview` mode and **choose** a `PR template`.

Read the [Contribution guideline](https://github.com/cam-inc/bento/blob/main/CONTRIBUTING.md).

- [General](?expand=1&template=general.md) to create any kind of PRs except for versioning.
- [Version](?expand=1&template=version.md) to set new version for packages.

---

NOTE: This is a workaround for [this](https://github.community/t/is-there-a-pull-request-template-selector-similar-to-issues/171838/8)
