### PR TITLE
feat: add placeholder type✨

### DIFF
--- a/examples/nextjs/pages/index.tsx
+++ b/examples/nextjs/pages/index.tsx
@@ -49,6 +49,7 @@ import { useCallback, useMemo, useState } from 'react';
 const Home: NextPage = () => {
   const config = useMemo<NonNullable<EditorProps['config']>>(
     () => ({
+      rootPlaceholder: 'Type something',
       elements: [
         elementParagraph,
         elementHeadingLevel01,

--- a/packages/core/src/config/index.ts
+++ b/packages/core/src/config/index.ts
@@ -13,7 +13,7 @@ import { ThemeToken } from '../theme/index.css';
 // All the custom elements and texts must follow this type.
 // @see: https://docs.slatejs.org/concepts/12-typescript#why-is-the-type-definition-unusual
 export type CustomElement<Attributes extends Record<string, any> = {}> = {
-  type?: string;
+  type: string;
   attributes?: Attributes;
   children: (CustomElement | CustomText)[];
 };
@@ -97,6 +97,7 @@ export type Config = {
   elements: Element[];
   texts: Text[];
   themeToken: PartialDeep<ThemeToken>;
+  rootPlaceholder?: string;
 };
 
 export type PickRequired<T extends Record<string, any>, K extends keyof T> = {

--- a/packages/core/src/editable/index.tsx
+++ b/packages/core/src/editable/index.tsx
@@ -77,6 +77,7 @@ export const Editable: React.FC<EditableProps> = () => {
         renderElement={renderElement}
         renderLeaf={renderLeaf}
         onDrop={handleDrop}
+        placeholder={config.rootPlaceholder}
       />
     </DndProvider>
   );

--- a/packages/core/src/editor/index.tsx
+++ b/packages/core/src/editor/index.tsx
@@ -3,6 +3,7 @@ import { createEditor, Element } from 'slate';
 import { Slate, withReact, ReactEditor } from 'slate-react';
 import { Config, CustomElement } from '../config';
 import { Editable } from '../editable';
+import { helpers } from '../helpers';
 import { ModalContainer } from '../portals/modal/container';
 import { PopoverContainer } from '../portals/popover/container';
 import {
@@ -97,6 +98,10 @@ export const Editor: React.FC<EditorProps> = ({
   );
 
   useEffect(() => {
+    !initialValue.length &&
+      helpers.logger.error({
+        messages: [`The initial value must have a child or more.`],
+      });
     ReactEditor.focus(editor);
   }, []);
 

--- a/packages/core/src/editor/index.tsx
+++ b/packages/core/src/editor/index.tsx
@@ -34,17 +34,13 @@ export type EditorProps = {
   config?: Config;
   // Rename to `initialvalue` for the <Slate> component's `value` props is only used as initial state for the editor.
   // @see:
-  initialValue?: CustomElement[];
+  initialValue: CustomElement[];
   onChange?: (value: BentoReturnData) => void;
 };
 export const Editor: React.FC<EditorProps> = ({
   config = { elements: [], texts: [], themeToken: {} },
-  initialValue = [
-    {
-      children: [{ text: '' }],
-    },
-  ],
-  onChange = () => { },
+  initialValue,
+  onChange = () => {},
 }) => {
   const editor = useMemo(() => {
     const editor = withReact(createEditor());

--- a/packages/core/src/element/container/index.css.ts
+++ b/packages/core/src/element/container/index.css.ts
@@ -90,22 +90,14 @@ const bodyPatched = style({
 const bodyPlaceholder = style({
   selectors: {
     [`${editorStyles.root} ${body} &`]: {
-      display: 'none',
+      display: 'flex',
+      alignItems: 'center',
       position: 'absolute',
       top: 0,
       bottom: 0,
       userSelect: 'none',
       pointerEvents: 'none',
       color: themeVars.color.backgroundOnSlight,
-    },
-  },
-});
-
-const bodyPlaceholderShown = style({
-  selectors: {
-    [`${editorStyles.root} ${body} &`]: {
-      display: 'flex',
-      alignItems: 'center',
     },
   },
 });
@@ -167,7 +159,6 @@ export const styles = {
   dropAreaInnerOver,
   body,
   bodyPlaceholder,
-  bodyPlaceholderShown,
   bodyPatched,
   utilsContainer,
   utilsContainerOver,

--- a/packages/core/src/element/container/index.css.ts
+++ b/packages/core/src/element/container/index.css.ts
@@ -7,8 +7,8 @@ const root = style({
     [`${editorStyles.root} &`]: {
       position: 'relative',
       margin: `${themeVars.space['4']} 0`,
-    }
-  }
+    },
+  },
 });
 
 const dropArea = style({
@@ -18,24 +18,24 @@ const dropArea = style({
       right: 0,
       left: 0,
       height: themeVars.space['0'],
-    }
-  }
+    },
+  },
 });
 
 const dropAreaAbove = style({
   selectors: {
     [`${editorStyles.root} &`]: {
       top: `calc(${themeVars.space['2']} * -1)`,
-    }
-  }
+    },
+  },
 });
 
 const dropAreaBelow = style({
   selectors: {
     [`${editorStyles.root} &`]: {
       bottom: `calc(${themeVars.space['2']} * -1)`,
-    }
-  }
+    },
+  },
 });
 
 const dropAreaInner = style({
@@ -50,8 +50,8 @@ const dropAreaInner = style({
       left: 0,
       margin: 'auto',
       opacity: 0,
-    }
-  }
+    },
+  },
 });
 
 const dropAreaInnerDroppable = style({
@@ -59,31 +59,55 @@ const dropAreaInnerDroppable = style({
     [`${editorStyles.root} &`]: {
       height: themeVars.space['2'],
       opacity: 0.08,
-    }
-  }
+    },
+  },
 });
 
 const dropAreaInnerOver = style({
   selectors: {
     [`${editorStyles.root} &`]: {
       opacity: 0.5,
-    }
-  }
+    },
+  },
 });
 
 const body = style({
   selectors: {
     [`${editorStyles.root} &`]: {
-    }
-  }
+      position: 'relative',
+    },
+  },
 });
 // @see: https://bugzilla.mozilla.org/show_bug.cgi?id=36854
 const bodyPatched = style({
   selectors: {
     [`${editorStyles.root} &`]: {
       display: 'inline-block',
-    }
-  }
+    },
+  },
+});
+
+const bodyPlaceholder = style({
+  selectors: {
+    [`${editorStyles.root} ${body} &`]: {
+      display: 'none',
+      position: 'absolute',
+      top: 0,
+      bottom: 0,
+      userSelect: 'none',
+      pointerEvents: 'none',
+      color: themeVars.color.backgroundOnSlight,
+    },
+  },
+});
+
+const bodyPlaceholderShown = style({
+  selectors: {
+    [`${editorStyles.root} ${body} &`]: {
+      display: 'flex',
+      alignItems: 'center',
+    },
+  },
 });
 
 const utilsContainer = style({
@@ -96,7 +120,7 @@ const utilsContainer = style({
       width: 0,
       height: 0,
     },
-  }
+  },
 });
 
 const utilsContainerOver = style({
@@ -104,7 +128,7 @@ const utilsContainerOver = style({
     [`${editorStyles.root} &`]: {
       display: 'block',
     },
-  }
+  },
 });
 
 const utils = style({
@@ -115,8 +139,8 @@ const utils = style({
       right: 0,
       display: 'flex',
       gap: 12,
-    }
-  }
+    },
+  },
 });
 
 const button = style({
@@ -130,9 +154,23 @@ const button = style({
       padding: themeVars.space['1'],
       color: themeVars.color.brand,
     },
-  }
+  },
 });
 
 export const styles = {
-  root, dropArea, dropAreaAbove, dropAreaBelow, dropAreaInner, dropAreaInnerDroppable, dropAreaInnerOver, body, bodyPatched, utilsContainer, utilsContainerOver, utils, button,
+  root,
+  dropArea,
+  dropAreaAbove,
+  dropAreaBelow,
+  dropAreaInner,
+  dropAreaInnerDroppable,
+  dropAreaInnerOver,
+  body,
+  bodyPlaceholder,
+  bodyPlaceholderShown,
+  bodyPatched,
+  utilsContainer,
+  utilsContainerOver,
+  utils,
+  button,
 };

--- a/packages/core/src/element/container/index.tsx
+++ b/packages/core/src/element/container/index.tsx
@@ -31,6 +31,7 @@ export type ElementContainerProps = RenderElementProps & {
   placeholder?: {
     text: string;
     className?: string;
+    isAlwaysShown?: boolean;
   };
 };
 
@@ -188,7 +189,8 @@ export const ElementContainer: React.FC<ElementContainerProps> = (props) => {
               contentEditable={false}
               className={classnames({
                 [styles.bodyPlaceholder]: true,
-                [styles.bodyPlaceholderShown]: isEmpty && isSelected,
+                [styles.bodyPlaceholderShown]:
+                  isEmpty && (props.placeholder.isAlwaysShown || isSelected),
               })}
             >
               <span className={props.placeholder.className}>

--- a/packages/core/src/element/container/index.tsx
+++ b/packages/core/src/element/container/index.tsx
@@ -1,11 +1,24 @@
 import classnames from 'classnames';
-import { ElementType, useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import {
+  ElementType,
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from 'react';
 import { useDrag, useDrop } from 'react-dnd';
 import { Path, Transforms } from 'slate';
-import { ReactEditor, RenderElementProps, useSlate } from 'slate-react';
+import {
+  ReactEditor,
+  RenderElementProps,
+  useSelected,
+  useSlate,
+} from 'slate-react';
 import { Button } from '../../components/button';
 import { DotsIcon } from '../../components/icons/dots';
 import { PlusIcon } from '../../components/icons/plus';
+import { helpers } from '../../helpers';
 import { Popover, usePopover } from '../../portals/popover';
 import { Toolbox } from '../../toolbox';
 import { Toolmenu } from '../../toolmenu';
@@ -15,6 +28,10 @@ export type ElementContainerProps = RenderElementProps & {
   utilsPositionY?: number;
   className?: string;
   as?: ElementType;
+  placeholder?: {
+    text: string;
+    className?: string;
+  };
 };
 
 export const ElementContainer: React.FC<ElementContainerProps> = (props) => {
@@ -39,6 +56,9 @@ export const ElementContainer: React.FC<ElementContainerProps> = (props) => {
   const handleToolmenuDone = useCallback(() => {
     popoverToolmenu.close();
   }, [popoverToolmenu]);
+
+  const isSelected = useSelected();
+  const isEmpty = helpers.Editor.isEmpty(editor, props.element);
 
   // DnD
   const type = 'Element';
@@ -156,10 +176,26 @@ export const ElementContainer: React.FC<ElementContainerProps> = (props) => {
             })}
           />
         </div>
-        <div className={classnames({
-          [styles.body]: true,
-          [styles.bodyPatched]: props.as === 'li'
-        })} ref={bodyRef}>
+        <div
+          className={classnames({
+            [styles.body]: true,
+            [styles.bodyPatched]: props.as === 'li',
+          })}
+          ref={bodyRef}
+        >
+          {props.placeholder && (
+            <div
+              contentEditable={false}
+              className={classnames({
+                [styles.bodyPlaceholder]: true,
+                [styles.bodyPlaceholderShown]: isEmpty && isSelected,
+              })}
+            >
+              <span className={props.placeholder.className}>
+                {props.placeholder.text}
+              </span>
+            </div>
+          )}
           {props.children}
         </div>
         <div

--- a/packages/core/src/element/container/index.tsx
+++ b/packages/core/src/element/container/index.tsx
@@ -28,11 +28,7 @@ export type ElementContainerProps = RenderElementProps & {
   utilsPositionY?: number;
   className?: string;
   as?: ElementType;
-  placeholder?: {
-    text: string;
-    className?: string;
-    unselectedShown?: boolean;
-  };
+  emptyState?: React.ReactNode;
 };
 
 export const ElementContainer: React.FC<ElementContainerProps> = (props) => {
@@ -184,20 +180,17 @@ export const ElementContainer: React.FC<ElementContainerProps> = (props) => {
           })}
           ref={bodyRef}
         >
-          {props.placeholder && (
+          {isEmpty && isSelected && !props.emptyState && (
             <div
               contentEditable={false}
               className={classnames({
                 [styles.bodyPlaceholder]: true,
-                [styles.bodyPlaceholderShown]:
-                  isEmpty && (props.placeholder.unselectedShown || isSelected),
               })}
             >
-              <span className={props.placeholder.className}>
-                {props.placeholder.text}
-              </span>
+              Type something
             </div>
           )}
+          {isEmpty && props.emptyState}
           {props.children}
         </div>
         <div

--- a/packages/core/src/element/container/index.tsx
+++ b/packages/core/src/element/container/index.tsx
@@ -31,7 +31,7 @@ export type ElementContainerProps = RenderElementProps & {
   placeholder?: {
     text: string;
     className?: string;
-    isAlwaysShown?: boolean;
+    unselectedShown?: boolean;
   };
 };
 
@@ -190,7 +190,7 @@ export const ElementContainer: React.FC<ElementContainerProps> = (props) => {
               className={classnames({
                 [styles.bodyPlaceholder]: true,
                 [styles.bodyPlaceholderShown]:
-                  isEmpty && (props.placeholder.isAlwaysShown || isSelected),
+                  isEmpty && (props.placeholder.unselectedShown || isSelected),
               })}
             >
               <span className={props.placeholder.className}>

--- a/packages/core/src/theme/index.css.ts
+++ b/packages/core/src/theme/index.css.ts
@@ -20,6 +20,7 @@ export const defaultThemeToken = {
     '6': '1.5rem',
     '8': '2rem',
     '9': '2.25rem',
+    '10': '2.5rem',
     '40': '10rem',
   },
   radius: {

--- a/packages/element-callout/src/editable/index.css.ts
+++ b/packages/element-callout/src/editable/index.css.ts
@@ -29,9 +29,17 @@ export const styles = {
       },
     },
   }),
-  placeholder: style({
+  emptyState: style({
     selectors: {
       [`.${EditorClassName} &`]: {
+        position: 'absolute',
+        top: 0,
+        bottom: 0,
+        display: 'flex',
+        alignItems: 'center',
+        userSelect: 'none',
+        pointerEvents: 'none',
+        color: themeVars.color.backgroundOnSlight,
         paddingLeft: `calc(${themeVars.space[4]} + 28px)`,
       },
     },

--- a/packages/element-callout/src/editable/index.css.ts
+++ b/packages/element-callout/src/editable/index.css.ts
@@ -19,7 +19,21 @@ export const styles = {
         display: 'block',
         width: 20,
         height: 20,
-      }
-    }
+      },
+    },
+  }),
+  text: style({
+    selectors: {
+      [`.${EditorClassName} &`]: {
+        minWidth: 1,
+      },
+    },
+  }),
+  placeholder: style({
+    selectors: {
+      [`.${EditorClassName} &`]: {
+        paddingLeft: `calc(${themeVars.space[4]} + 28px)`,
+      },
+    },
   }),
 };

--- a/packages/element-callout/src/editable/index.tsx
+++ b/packages/element-callout/src/editable/index.tsx
@@ -6,7 +6,7 @@ const editable: Element<Attributes>['editable'] = {
   defaultValue: [
     {
       type: 'format',
-      text: '入力してください',
+      text: '',
     },
   ],
   Component: (props) => {
@@ -14,11 +14,9 @@ const editable: Element<Attributes>['editable'] = {
       <ElementContainer
         {...props}
         utilsPositionY={9}
-        placeholder={{
-          text: 'Type something',
-          className: styles.placeholder,
-          unselectedShown: true,
-        }}
+        emptyState={
+          <span className={styles.emptyState}>Type something...</span>
+        }
       >
         <div className={styles.root}>
           <div className={styles.icon}>

--- a/packages/element-callout/src/editable/index.tsx
+++ b/packages/element-callout/src/editable/index.tsx
@@ -11,14 +11,20 @@ const editable: Element<Attributes>['editable'] = {
   ],
   Component: (props) => {
     return (
-      <ElementContainer {...props} utilsPositionY={9}>
+      <ElementContainer
+        {...props}
+        utilsPositionY={9}
+        placeholder={{
+          text: 'Type something',
+          className: styles.placeholder,
+          unselectedShown: true,
+        }}
+      >
         <div className={styles.root}>
           <div className={styles.icon}>
             <ExclamationIcon type="callout" />
           </div>
-          <div>
-            {props.children}
-          </div>
+          <div className={styles.text}>{props.children}</div>
         </div>
       </ElementContainer>
     );

--- a/packages/element-heading/src/level01/editable/index.css.ts
+++ b/packages/element-heading/src/level01/editable/index.css.ts
@@ -12,11 +12,17 @@ export const styles = {
       },
     },
   }),
-  placeholder: style({
+  emptyState: style({
     selectors: {
       [`.${EditorClassName} &`]: {
+        position: 'absolute',
+        top: 0,
+        bottom: 0,
         fontSize: themeVars.fontSize.heading.large,
         fontWeight: 'bold',
+        userSelect: 'none',
+        pointerEvents: 'none',
+        color: themeVars.color.backgroundOnSlight,
       },
     },
   }),

--- a/packages/element-heading/src/level01/editable/index.css.ts
+++ b/packages/element-heading/src/level01/editable/index.css.ts
@@ -16,6 +16,7 @@ export const styles = {
     selectors: {
       [`.${EditorClassName} &`]: {
         fontSize: themeVars.fontSize.heading.large,
+        fontWeight: 'bold',
       },
     },
   }),

--- a/packages/element-heading/src/level01/editable/index.css.ts
+++ b/packages/element-heading/src/level01/editable/index.css.ts
@@ -11,5 +11,12 @@ export const styles = {
         color: themeVars.color.backgroundOn,
       },
     },
-  })
+  }),
+  placeholder: style({
+    selectors: {
+      [`.${EditorClassName} &`]: {
+        fontSize: themeVars.fontSize.heading.large,
+      },
+    },
+  }),
 };

--- a/packages/element-heading/src/level01/editable/index.tsx
+++ b/packages/element-heading/src/level01/editable/index.tsx
@@ -9,7 +9,11 @@ const editable: Element<Attributes>['editable'] = {
       <ElementContainer
         {...props}
         utilsPositionY={7}
-        placeholder={{ text: 'Heading 1', className: styles.placeholder }}
+        placeholder={{
+          text: 'Heading 1',
+          className: styles.placeholder,
+          unselectedShown: true,
+        }}
       >
         <h1 className={styles.root}>{props.children}</h1>
       </ElementContainer>

--- a/packages/element-heading/src/level01/editable/index.tsx
+++ b/packages/element-heading/src/level01/editable/index.tsx
@@ -3,17 +3,13 @@ import { Attributes } from '../attributes';
 import { styles } from './index.css';
 
 const editable: Element<Attributes>['editable'] = {
-  defaultValue: [{ type: 'format', text: '大見出し' }],
+  defaultValue: [{ type: 'format', text: '' }],
   Component: (props) => {
     return (
       <ElementContainer
         {...props}
         utilsPositionY={7}
-        placeholder={{
-          text: 'Heading 1',
-          className: styles.placeholder,
-          unselectedShown: true,
-        }}
+        emptyState={<span className={styles.emptyState}>Heading 1</span>}
       >
         <h1 className={styles.root}>{props.children}</h1>
       </ElementContainer>

--- a/packages/element-heading/src/level01/editable/index.tsx
+++ b/packages/element-heading/src/level01/editable/index.tsx
@@ -6,7 +6,11 @@ const editable: Element<Attributes>['editable'] = {
   defaultValue: [{ type: 'format', text: '大見出し' }],
   Component: (props) => {
     return (
-      <ElementContainer {...props} utilsPositionY={7}>
+      <ElementContainer
+        {...props}
+        utilsPositionY={7}
+        placeholder={{ text: 'Heading 1', className: styles.placeholder }}
+      >
         <h1 className={styles.root}>{props.children}</h1>
       </ElementContainer>
     );

--- a/packages/element-heading/src/level02/editable/index.css.ts
+++ b/packages/element-heading/src/level02/editable/index.css.ts
@@ -11,5 +11,13 @@ export const styles = {
         color: themeVars.color.backgroundOn,
       },
     },
-  })
+  }),
+  placeholder: style({
+    selectors: {
+      [`.${EditorClassName} &`]: {
+        fontSize: themeVars.fontSize.heading.medium,
+        fontWeight: 'bold',
+      },
+    },
+  }),
 };

--- a/packages/element-heading/src/level02/editable/index.css.ts
+++ b/packages/element-heading/src/level02/editable/index.css.ts
@@ -12,11 +12,17 @@ export const styles = {
       },
     },
   }),
-  placeholder: style({
+  emptyState: style({
     selectors: {
       [`.${EditorClassName} &`]: {
+        position: 'absolute',
+        top: 0,
+        bottom: 0,
         fontSize: themeVars.fontSize.heading.medium,
         fontWeight: 'bold',
+        userSelect: 'none',
+        pointerEvents: 'none',
+        color: themeVars.color.backgroundOnSlight,
       },
     },
   }),

--- a/packages/element-heading/src/level02/editable/index.tsx
+++ b/packages/element-heading/src/level02/editable/index.tsx
@@ -6,7 +6,15 @@ const editable: Element<Attributes>['editable'] = {
   defaultValue: [{ type: 'format', text: '中見出し' }],
   Component: (props) => {
     return (
-      <ElementContainer {...props} utilsPositionY={5}>
+      <ElementContainer
+        {...props}
+        utilsPositionY={5}
+        placeholder={{
+          text: 'Heading 2',
+          className: styles.placeholder,
+          unselectedShown: true,
+        }}
+      >
         <h2 className={styles.root}>{props.children}</h2>
       </ElementContainer>
     );

--- a/packages/element-heading/src/level02/editable/index.tsx
+++ b/packages/element-heading/src/level02/editable/index.tsx
@@ -3,17 +3,13 @@ import { Attributes } from '../attributes';
 import { styles } from './index.css';
 
 const editable: Element<Attributes>['editable'] = {
-  defaultValue: [{ type: 'format', text: '中見出し' }],
+  defaultValue: [{ type: 'format', text: '' }],
   Component: (props) => {
     return (
       <ElementContainer
         {...props}
         utilsPositionY={5}
-        placeholder={{
-          text: 'Heading 2',
-          className: styles.placeholder,
-          unselectedShown: true,
-        }}
+        emptyState={<span className={styles.emptyState}>Heading 2</span>}
       >
         <h2 className={styles.root}>{props.children}</h2>
       </ElementContainer>

--- a/packages/element-heading/src/level03/editable/index.css.ts
+++ b/packages/element-heading/src/level03/editable/index.css.ts
@@ -11,5 +11,13 @@ export const styles = {
         color: themeVars.color.backgroundOn,
       },
     },
-  })
+  }),
+  placeholder: style({
+    selectors: {
+      [`.${EditorClassName} &`]: {
+        fontSize: themeVars.fontSize.heading.small,
+        fontWeight: 'bold',
+      },
+    },
+  }),
 };

--- a/packages/element-heading/src/level03/editable/index.css.ts
+++ b/packages/element-heading/src/level03/editable/index.css.ts
@@ -12,11 +12,17 @@ export const styles = {
       },
     },
   }),
-  placeholder: style({
+  emptyState: style({
     selectors: {
       [`.${EditorClassName} &`]: {
+        position: 'absolute',
+        top: 0,
+        bottom: 0,
         fontSize: themeVars.fontSize.heading.small,
         fontWeight: 'bold',
+        userSelect: 'none',
+        pointerEvents: 'none',
+        color: themeVars.color.backgroundOnSlight,
       },
     },
   }),

--- a/packages/element-heading/src/level03/editable/index.tsx
+++ b/packages/element-heading/src/level03/editable/index.tsx
@@ -3,17 +3,13 @@ import { Attributes } from '../attributes';
 import { styles } from './index.css';
 
 const editable: Element<Attributes>['editable'] = {
-  defaultValue: [{ type: 'format', text: '小見出し' }],
+  defaultValue: [{ type: 'format', text: '' }],
   Component: (props) => {
     return (
       <ElementContainer
         {...props}
         utilsPositionY={3}
-        placeholder={{
-          text: 'Heading 3',
-          className: styles.placeholder,
-          unselectedShown: true,
-        }}
+        emptyState={<span className={styles.emptyState}>Heading 3</span>}
       >
         <h3 className={styles.root}>{props.children}</h3>
       </ElementContainer>

--- a/packages/element-heading/src/level03/editable/index.tsx
+++ b/packages/element-heading/src/level03/editable/index.tsx
@@ -6,7 +6,15 @@ const editable: Element<Attributes>['editable'] = {
   defaultValue: [{ type: 'format', text: '小見出し' }],
   Component: (props) => {
     return (
-      <ElementContainer {...props} utilsPositionY={3}>
+      <ElementContainer
+        {...props}
+        utilsPositionY={3}
+        placeholder={{
+          text: 'Heading 3',
+          className: styles.placeholder,
+          unselectedShown: true,
+        }}
+      >
         <h3 className={styles.root}>{props.children}</h3>
       </ElementContainer>
     );

--- a/packages/element-list/src/item/editable/index.css.ts
+++ b/packages/element-list/src/item/editable/index.css.ts
@@ -6,10 +6,15 @@ export const styles = {
     color: themeVars.color.backgroundOn,
     minWidth: 1,
   }),
-  placeholder: style({
+  emptyState: style({
     selectors: {
       [`.${EditorClassName} &`]: {
-        // fontSize: themeVars.fontSize.heading.large,
+        position: 'absolute',
+        top: 0,
+        bottom: 0,
+        userSelect: 'none',
+        pointerEvents: 'none',
+        color: themeVars.color.backgroundOnSlight,
       },
     },
   }),

--- a/packages/element-list/src/item/editable/index.css.ts
+++ b/packages/element-list/src/item/editable/index.css.ts
@@ -1,8 +1,16 @@
 import { style } from '@vanilla-extract/css';
-import { themeVars } from '@bento-editor/core';
+import { EditorClassName, themeVars } from '@bento-editor/core';
 
 export const styles = {
   root: style({
     color: themeVars.color.backgroundOn,
-  })
+    minWidth: 1,
+  }),
+  placeholder: style({
+    selectors: {
+      [`.${EditorClassName} &`]: {
+        // fontSize: themeVars.fontSize.heading.large,
+      },
+    },
+  }),
 };

--- a/packages/element-list/src/item/editable/index.tsx
+++ b/packages/element-list/src/item/editable/index.tsx
@@ -12,7 +12,16 @@ const editable: Element<Attributes>['editable'] = {
   ],
   Component: (props) => {
     return (
-      <ElementContainer {...props} as="li" utilsPositionY={-2}>
+      <ElementContainer
+        {...props}
+        as="li"
+        utilsPositionY={-2}
+        placeholder={{
+          text: 'List',
+          className: styles.placeholder,
+          unselectedShown: true,
+        }}
+      >
         <div className={styles.root}>{props.children}</div>
       </ElementContainer>
     );

--- a/packages/element-list/src/item/editable/index.tsx
+++ b/packages/element-list/src/item/editable/index.tsx
@@ -16,11 +16,7 @@ const editable: Element<Attributes>['editable'] = {
         {...props}
         as="li"
         utilsPositionY={-2}
-        placeholder={{
-          text: 'List',
-          className: styles.placeholder,
-          unselectedShown: true,
-        }}
+        emptyState={<span className={styles.emptyState}>List</span>}
       >
         <div className={styles.root}>{props.children}</div>
       </ElementContainer>

--- a/packages/element-list/src/todo-item/editable/index.css.ts
+++ b/packages/element-list/src/todo-item/editable/index.css.ts
@@ -27,9 +27,15 @@ export const styles = {
       },
     },
   }),
-  placeholder: style({
+  emptyState: style({
     selectors: {
       [`.${EditorClassName} &`]: {
+        position: 'absolute',
+        top: 0,
+        bottom: 0,
+        userSelect: 'none',
+        pointerEvents: 'none',
+        color: themeVars.color.backgroundOnSlight,
         paddingLeft: `calc(${themeVars.space[6]} + 3px)`,
         whiteSpace: 'pre',
       },

--- a/packages/element-list/src/todo-item/editable/index.css.ts
+++ b/packages/element-list/src/todo-item/editable/index.css.ts
@@ -11,12 +11,27 @@ export const styles = {
       },
     },
   }),
+  text: style({
+    selectors: {
+      [`.${EditorClassName} &`]: {
+        minWidth: 1,
+      },
+    },
+  }),
   checkbox: style({
     selectors: {
       [`.${EditorClassName} &`]: {
         display: 'block',
         width: 18,
         height: 18,
+      },
+    },
+  }),
+  placeholder: style({
+    selectors: {
+      [`.${EditorClassName} &`]: {
+        paddingLeft: `calc(${themeVars.space[6]} + 3px)`,
+        whiteSpace: 'pre',
       },
     },
   }),

--- a/packages/element-list/src/todo-item/editable/index.tsx
+++ b/packages/element-list/src/todo-item/editable/index.tsx
@@ -32,12 +32,21 @@ const editable: Element<Attributes>['editable'] = {
     );
 
     return (
-      <ElementContainer {...props} as="li" utilsPositionY={-3}>
+      <ElementContainer
+        {...props}
+        as="li"
+        utilsPositionY={-3}
+        placeholder={{
+          text: 'To-do',
+          className: styles.placeholder,
+          unselectedShown: true,
+        }}
+      >
         <div className={styles.root}>
           <span className={styles.checkbox} contentEditable={false}>
             <CheckboxIcon checked={checked} onClick={handleCheckboxClick} />
           </span>
-          {props.children}
+          <div className={styles.text}>{props.children}</div>
         </div>
       </ElementContainer>
     );

--- a/packages/element-list/src/todo-item/editable/index.tsx
+++ b/packages/element-list/src/todo-item/editable/index.tsx
@@ -36,11 +36,7 @@ const editable: Element<Attributes>['editable'] = {
         {...props}
         as="li"
         utilsPositionY={-3}
-        placeholder={{
-          text: 'To-do',
-          className: styles.placeholder,
-          unselectedShown: true,
-        }}
+        emptyState={<span className={styles.emptyState}>To-do</span>}
       >
         <div className={styles.root}>
           <span className={styles.checkbox} contentEditable={false}>

--- a/packages/element-note/src/editable/index.css.ts
+++ b/packages/element-note/src/editable/index.css.ts
@@ -29,9 +29,17 @@ export const styles = {
       },
     },
   }),
-  placeholder: style({
+  emptyState: style({
     selectors: {
       [`.${EditorClassName} &`]: {
+        position: 'absolute',
+        top: 0,
+        bottom: 0,
+        display: 'flex',
+        alignItems: 'center',
+        userSelect: 'none',
+        pointerEvents: 'none',
+        color: themeVars.color.backgroundOnSlight,
         paddingLeft: `calc(${themeVars.space[4]} + 28px)`,
       },
     },

--- a/packages/element-note/src/editable/index.css.ts
+++ b/packages/element-note/src/editable/index.css.ts
@@ -19,7 +19,21 @@ export const styles = {
         display: 'block',
         width: 20,
         height: 20,
-      }
-    }
+      },
+    },
+  }),
+  text: style({
+    selectors: {
+      [`.${EditorClassName} &`]: {
+        minWidth: 1,
+      },
+    },
+  }),
+  placeholder: style({
+    selectors: {
+      [`.${EditorClassName} &`]: {
+        paddingLeft: `calc(${themeVars.space[4]} + 28px)`,
+      },
+    },
   }),
 };

--- a/packages/element-note/src/editable/index.tsx
+++ b/packages/element-note/src/editable/index.tsx
@@ -6,7 +6,7 @@ const editable: Element<Attributes>['editable'] = {
   defaultValue: [
     {
       type: 'format',
-      text: '入力してください',
+      text: '',
     },
   ],
   Component: (props) => {
@@ -14,11 +14,9 @@ const editable: Element<Attributes>['editable'] = {
       <ElementContainer
         {...props}
         utilsPositionY={9}
-        placeholder={{
-          text: 'Type something',
-          className: styles.placeholder,
-          unselectedShown: true,
-        }}
+        emptyState={
+          <span className={styles.emptyState}>Type something...</span>
+        }
       >
         <div className={styles.root}>
           <div className={styles.icon}>

--- a/packages/element-note/src/editable/index.tsx
+++ b/packages/element-note/src/editable/index.tsx
@@ -11,14 +11,20 @@ const editable: Element<Attributes>['editable'] = {
   ],
   Component: (props) => {
     return (
-      <ElementContainer {...props} utilsPositionY={9}>
+      <ElementContainer
+        {...props}
+        utilsPositionY={9}
+        placeholder={{
+          text: 'Type something',
+          className: styles.placeholder,
+          unselectedShown: true,
+        }}
+      >
         <div className={styles.root}>
           <div className={styles.icon}>
             <ExclamationIcon type="note" />
           </div>
-          <div>
-            {props.children}
-          </div>
+          <div className={styles.text}>{props.children}</div>
         </div>
       </ElementContainer>
     );

--- a/packages/element-paragraph/src/editable/index.tsx
+++ b/packages/element-paragraph/src/editable/index.tsx
@@ -6,7 +6,11 @@ const editable: Element<Attributes>['editable'] = {
   defaultValue: [{ type: 'format', text: 'default value', attributes: {} }],
   Component: (props) => {
     return (
-      <ElementContainer {...props} utilsPositionY={-1}>
+      <ElementContainer
+        {...props}
+        utilsPositionY={-1}
+        placeholder={{ text: 'Type something' }}
+      >
         <p className={styles.root}>{props.children}</p>
       </ElementContainer>
     );

--- a/packages/element-paragraph/src/index.ts
+++ b/packages/element-paragraph/src/index.ts
@@ -12,6 +12,6 @@ const element: Element<Attributes> = {
   normalizeNode: (/*editor, entry*/) => {
     // TODO: textのみを許可。
     return false;
-  }
+  },
 };
 export default element;

--- a/packages/element-quote/src/editable/index.css.ts
+++ b/packages/element-quote/src/editable/index.css.ts
@@ -7,7 +7,7 @@ export const styles = {
       [`.${EditorClassName} &`]: {
         paddingLeft: themeVars.space['3'],
         borderLeft: `${themeVars.space['0.5']} solid ${themeVars.color.backgroundOnLow}`,
-      }
+      },
     },
   }),
   blockquote: style({
@@ -15,14 +15,14 @@ export const styles = {
       [`.${EditorClassName} &`]: {
         color: themeVars.color.backgroundOnLow,
         fontSize: themeVars.fontSize.label.large,
-      }
+      },
     },
   }),
   cite: style({
     selectors: {
       [`.${EditorClassName} &`]: {
         marginTop: themeVars.space['3'],
-      }
+      },
     },
   }),
   input: style({
@@ -35,7 +35,16 @@ export const styles = {
         padding: 0,
         color: themeVars.color.backgroundOnLow,
         fontSize: themeVars.fontSize.label.small,
-      }
+      },
+    },
+  }),
+  placeholder: style({
+    selectors: {
+      [`.${EditorClassName} &`]: {
+        position: 'absolute',
+        top: 0,
+        paddingLeft: themeVars.space['4'],
+      },
     },
   }),
 };

--- a/packages/element-quote/src/editable/index.css.ts
+++ b/packages/element-quote/src/editable/index.css.ts
@@ -38,11 +38,14 @@ export const styles = {
       },
     },
   }),
-  placeholder: style({
+  emptyState: style({
     selectors: {
       [`.${EditorClassName} &`]: {
         position: 'absolute',
         top: 0,
+        userSelect: 'none',
+        pointerEvents: 'none',
+        color: themeVars.color.backgroundOnSlight,
         paddingLeft: themeVars.space['4'],
       },
     },

--- a/packages/element-quote/src/editable/index.tsx
+++ b/packages/element-quote/src/editable/index.tsx
@@ -8,24 +8,42 @@ const editable: Element<Attributes>['editable'] = {
   Component: (props) => {
     const cite = props.element.attributes?.cite;
 
-    const handleCiteChange = useCallback((e: ChangeEvent<HTMLInputElement>) => {
-      const { value } = e.currentTarget;
-      helpers.Transforms.setNodes(props.editor, {
-        attributes: {
-          cite: value,
-        }
-      }, {
-        at: helpers.ReactEditor.findPath(props.editor, props.element)
-      });
-    }, [props.editor, props.element]);
-
+    const handleCiteChange = useCallback(
+      (e: ChangeEvent<HTMLInputElement>) => {
+        const { value } = e.currentTarget;
+        helpers.Transforms.setNodes(
+          props.editor,
+          {
+            attributes: {
+              cite: value,
+            },
+          },
+          {
+            at: helpers.ReactEditor.findPath(props.editor, props.element),
+          }
+        );
+      },
+      [props.editor, props.element]
+    );
 
     return (
-      <ElementContainer {...props}>
+      <ElementContainer
+        {...props}
+        placeholder={{
+          text: 'Empty quote',
+          className: styles.placeholder,
+          unselectedShown: true,
+        }}
+      >
         <div className={styles.root}>
           <div className={styles.blockquote}>{props.children}</div>
           <div className={styles.cite} contentEditable={false}>
-            <input className={styles.input} value={cite} placeholder="引用元を追加" onChange={handleCiteChange} />
+            <input
+              className={styles.input}
+              value={cite}
+              placeholder="引用元を追加"
+              onChange={handleCiteChange}
+            />
           </div>
         </div>
       </ElementContainer>

--- a/packages/element-quote/src/editable/index.tsx
+++ b/packages/element-quote/src/editable/index.tsx
@@ -29,11 +29,7 @@ const editable: Element<Attributes>['editable'] = {
     return (
       <ElementContainer
         {...props}
-        placeholder={{
-          text: 'Empty quote',
-          className: styles.placeholder,
-          unselectedShown: true,
-        }}
+        emptyState={<span className={styles.emptyState}>Empty quote</span>}
       >
         <div className={styles.root}>
           <div className={styles.blockquote}>{props.children}</div>

--- a/packages/element-toggle/src/body/editable/index.css.ts
+++ b/packages/element-toggle/src/body/editable/index.css.ts
@@ -5,7 +5,7 @@ export const styles = {
   container: style({
     selectors: {
       [`.${EditorClassName} &`]: {
-        marginLeft: themeVars.space['9'],
+        marginLeft: themeVars.space['10'],
       },
     },
   }),
@@ -14,6 +14,18 @@ export const styles = {
       [`.${EditorClassName} &`]: {
         color: themeVars.color.backgroundOnLow,
         fontSize: themeVars.fontSize.label.large,
+      },
+    },
+  }),
+  emptyState: style({
+    selectors: {
+      [`.${EditorClassName} &`]: {
+        position: 'absolute',
+        top: 0,
+        bottom: 0,
+        userSelect: 'none',
+        pointerEvents: 'none',
+        color: themeVars.color.backgroundOnSlight,
       },
     },
   }),

--- a/packages/element-toggle/src/body/editable/index.css.ts
+++ b/packages/element-toggle/src/body/editable/index.css.ts
@@ -6,8 +6,8 @@ export const styles = {
     selectors: {
       [`.${EditorClassName} &`]: {
         marginLeft: themeVars.space['9'],
-      }
-    }
+      },
+    },
   }),
   root: style({
     selectors: {
@@ -16,5 +16,5 @@ export const styles = {
         fontSize: themeVars.fontSize.label.large,
       },
     },
-  })
+  }),
 };

--- a/packages/element-toggle/src/body/editable/index.tsx
+++ b/packages/element-toggle/src/body/editable/index.tsx
@@ -18,7 +18,15 @@ const editable: Element<Attributes>['editable'] = {
       return null;
     }
     return (
-      <ElementContainer {...props} className={styles.container} utilsPositionY={-1}>
+      <ElementContainer
+        {...props}
+        className={styles.container}
+        utilsPositionY={-1}
+        placeholder={{
+          text: 'Empty toggle. Type something',
+          unselectedShown: true,
+        }}
+      >
         <div className={styles.root}>{props.children}</div>
       </ElementContainer>
     );

--- a/packages/element-toggle/src/body/editable/index.tsx
+++ b/packages/element-toggle/src/body/editable/index.tsx
@@ -9,7 +9,7 @@ const editable: Element<Attributes>['editable'] = {
     {
       type: 'format',
       attributes: {},
-      text: 'default body',
+      text: '',
     },
   ],
   Component: (props) => {
@@ -22,10 +22,11 @@ const editable: Element<Attributes>['editable'] = {
         {...props}
         className={styles.container}
         utilsPositionY={-1}
-        placeholder={{
-          text: 'Empty toggle. Type something',
-          unselectedShown: true,
-        }}
+        emptyState={
+          <span className={styles.emptyState}>
+            Empty toggle. Type something...
+          </span>
+        }
       >
         <div className={styles.root}>{props.children}</div>
       </ElementContainer>

--- a/packages/element-toggle/src/head/editable/index.css.ts
+++ b/packages/element-toggle/src/head/editable/index.css.ts
@@ -38,9 +38,17 @@ export const styles = {
       },
     },
   }),
-  placeholder: style({
+  emptyState: style({
     selectors: {
       [`.${EditorClassName} &`]: {
+        position: 'absolute',
+        top: 0,
+        bottom: 0,
+        display: 'flex',
+        alignItems: 'center',
+        userSelect: 'none',
+        pointerEvents: 'none',
+        color: themeVars.color.backgroundOnSlight,
         paddingLeft: `calc(${themeVars.space[2]} + 32px)`,
       },
     },

--- a/packages/element-toggle/src/head/editable/index.css.ts
+++ b/packages/element-toggle/src/head/editable/index.css.ts
@@ -15,8 +15,7 @@ export const styles = {
   }),
   ctrl: style({
     selectors: {
-      [`.${EditorClassName} &`]: {
-      },
+      [`.${EditorClassName} &`]: {},
     },
   }),
   opener: style({
@@ -35,6 +34,14 @@ export const styles = {
   body: style({
     selectors: {
       [`.${EditorClassName} &`]: {
+        minWidth: 1,
+      },
+    },
+  }),
+  placeholder: style({
+    selectors: {
+      [`.${EditorClassName} &`]: {
+        paddingLeft: `calc(${themeVars.space[2]} + 32px)`,
       },
     },
   }),

--- a/packages/element-toggle/src/head/editable/index.tsx
+++ b/packages/element-toggle/src/head/editable/index.tsx
@@ -14,7 +14,7 @@ const editable: Element<Attributes>['editable'] = {
     {
       type: 'format',
       attributes: {},
-      text: 'default head',
+      text: '',
     },
   ],
   Component: (props) => {
@@ -36,11 +36,7 @@ const editable: Element<Attributes>['editable'] = {
       <ElementContainer
         {...props}
         utilsPositionY={4}
-        placeholder={{
-          text: 'Toggle',
-          className: styles.placeholder,
-          unselectedShown: true,
-        }}
+        emptyState={<span className={styles.emptyState}>Toggle</span>}
       >
         <div className={styles.root}>
           <div className={styles.ctrl} contentEditable={false}>

--- a/packages/element-toggle/src/head/editable/index.tsx
+++ b/packages/element-toggle/src/head/editable/index.tsx
@@ -33,10 +33,22 @@ const editable: Element<Attributes>['editable'] = {
     }, [JSON.stringify(props.editor), parentElement]);
 
     return (
-      <ElementContainer {...props} utilsPositionY={4}>
+      <ElementContainer
+        {...props}
+        utilsPositionY={4}
+        placeholder={{
+          text: 'Toggle',
+          className: styles.placeholder,
+          unselectedShown: true,
+        }}
+      >
         <div className={styles.root}>
           <div className={styles.ctrl} contentEditable={false}>
-            <button type="button" className={styles.opener} onClick={handleCtrlClick}>
+            <button
+              type="button"
+              className={styles.opener}
+              onClick={handleCtrlClick}
+            >
               <OpenerIcon isOpened={parentElement.attributes?.isOpen} />
             </button>
           </div>


### PR DESCRIPTION
## Summary
- initial valueを必須にする
- editable にplaceholderを渡せるように
- element にplaceholderを渡せるように

**実装例**
```tsx
// paragraph
      <ElementContainer
        {...props}
        utilsPositionY={-1}
        placeholder={{ text: 'Type something' }}
      >
        <p className={styles.root}>{props.children}</p>
      </ElementContainer>
```

**サンプル**
[![Image from Gyazo](https://i.gyazo.com/ff162c1c255f77ef9658a2c683d7d2f8.gif)](https://gyazo.com/ff162c1c255f77ef9658a2c683d7d2f8)

## Reference(s)

Provide references that relate to your PR, if any.

- slate placeholder sample
- [link](https://github.com/ianstormtaylor/slate/blob/main/site/examples/custom-placeholder.tsx)
