### PR TITLE
refactor: remove transform and editor helper📦

### DIFF
--- a/packages/core/src/element/container/index.tsx
+++ b/packages/core/src/element/container/index.tsx
@@ -56,7 +56,7 @@ export const ElementContainer: React.FC<ElementContainerProps> = (props) => {
   }, [popoverToolmenu]);
 
   const isSelected = useSelected();
-  const isEmpty = helpers.Editor.isEmpty(editor, props.element);
+  const isEmpty = editor.isEmpty(props.element);
 
   // DnD
   const type = 'Element';

--- a/packages/core/src/element/container/index.tsx
+++ b/packages/core/src/element/container/index.tsx
@@ -8,7 +8,7 @@ import {
   useState,
 } from 'react';
 import { useDrag, useDrop } from 'react-dnd';
-import { Path, Transforms } from 'slate';
+import { Path } from 'slate';
 import {
   ReactEditor,
   RenderElementProps,
@@ -18,7 +18,6 @@ import {
 import { Button } from '../../components/button';
 import { DotsIcon } from '../../components/icons/dots';
 import { PlusIcon } from '../../components/icons/plus';
-import { helpers } from '../../helpers';
 import { Popover, usePopover } from '../../portals/popover';
 import { Toolbox } from '../../toolbox';
 import { Toolmenu } from '../../toolmenu';
@@ -82,7 +81,7 @@ export const ElementContainer: React.FC<ElementContainerProps> = (props) => {
     return {
       accept: type,
       drop: (item) => {
-        Transforms.moveNodes(editor, {
+        editor.moveNodes({
           at: item.from,
           to: path,
         });
@@ -120,7 +119,7 @@ export const ElementContainer: React.FC<ElementContainerProps> = (props) => {
             to = Path.next(path);
             break;
         }
-        Transforms.moveNodes(editor, {
+        editor.moveNodes({
           at: item.from,
           to,
         });

--- a/packages/core/src/helpers/child/index.tsx
+++ b/packages/core/src/helpers/child/index.tsx
@@ -1,4 +1,4 @@
-import { Editor, Element, Node, NodeEntry, Transforms } from 'slate';
+import { Editor, Element, Node, NodeEntry } from 'slate';
 import { warn } from '../logger';
 
 export const restrictChild = (
@@ -20,7 +20,7 @@ export const restrictChild = (
           },
         ],
       });
-      Transforms.removeNodes(editor, {
+      editor.removeNodes({
         at: childPath,
       });
       isRestricted = true;

--- a/packages/core/src/helpers/editor/index.ts
+++ b/packages/core/src/helpers/editor/index.ts
@@ -1,3 +1,0 @@
-import { Editor as SlateEditor } from 'slate';
-
-export default SlateEditor;

--- a/packages/core/src/helpers/index.ts
+++ b/packages/core/src/helpers/index.ts
@@ -1,24 +1,21 @@
 import { style } from '@vanilla-extract/css';
-import Editor from './editor';
 import Element, * as elements from './element';
 import * as logger from './logger';
 import * as error from './error';
 import Node from './node';
 import Path, * as pathHelpers from './path';
 import ReactEditor from './reactEditor';
-import Transforms, * as transforms from './transform';
+import * as transforms from './transform';
 import Text, * as textHelpers from './text';
 import * as childHelpers from './child';
 
 export const helpers = {
-  Editor,
   ReactEditor,
   Element,
   logger,
   error,
   Node,
   Path,
-  Transforms,
   ...transforms,
   Text,
   style,

--- a/packages/core/src/helpers/text/index.ts
+++ b/packages/core/src/helpers/text/index.ts
@@ -3,7 +3,7 @@ import { Editor, Text as SlateText } from 'slate';
 export const isText = SlateText.isText;
 
 export const hasAttribute = (editor: Editor, key: string) => {
-  const marks = Editor.marks(editor);
+  const marks = editor.marks;
   if (!marks?.attributes) {
     return false;
   }
@@ -11,7 +11,7 @@ export const hasAttribute = (editor: Editor, key: string) => {
 };
 
 export const removeTextAttribute = (editor: Editor, attribute: string) => {
-  const marks = Object.assign({}, Editor.marks(editor)?.attributes);
+  const marks = Object.assign({}, editor.marks?.attributes);
   delete marks[attribute];
   editor.setNodes(
     {
@@ -28,7 +28,7 @@ export const setTextAttribute = (
   editor.setNodes(
     {
       attributes: {
-        ...Editor.marks(editor)?.attributes,
+        ...editor.marks?.attributes,
         ...newAttributes,
       },
     },

--- a/packages/core/src/helpers/text/index.ts
+++ b/packages/core/src/helpers/text/index.ts
@@ -1,4 +1,4 @@
-import { Editor, Text as SlateText, Transforms } from 'slate';
+import { Editor, Text as SlateText } from 'slate';
 
 export const isText = SlateText.isText;
 
@@ -13,8 +13,7 @@ export const hasAttribute = (editor: Editor, key: string) => {
 export const removeTextAttribute = (editor: Editor, attribute: string) => {
   const marks = Object.assign({}, Editor.marks(editor)?.attributes);
   delete marks[attribute];
-  Transforms.setNodes(
-    editor,
+  editor.setNodes(
     {
       attributes: marks,
     },
@@ -26,8 +25,7 @@ export const setTextAttribute = (
   editor: Editor,
   newAttributes: Record<string, any>
 ) => {
-  Transforms.setNodes(
-    editor,
+  editor.setNodes(
     {
       attributes: {
         ...Editor.marks(editor)?.attributes,

--- a/packages/core/src/helpers/transform/index.ts
+++ b/packages/core/src/helpers/transform/index.ts
@@ -2,8 +2,6 @@ import { useCallback } from 'react';
 import { Transforms as SlateTransforms } from 'slate';
 import { ReactEditor, useSlate } from 'slate-react';
 
-export default SlateTransforms;
-
 export const useTransformsSetNodes = (
   element: Parameters<typeof ReactEditor.findPath>[1]
 ) => {

--- a/packages/core/src/plugins/withInsertSoftBreak.ts
+++ b/packages/core/src/plugins/withInsertSoftBreak.ts
@@ -9,7 +9,7 @@ export const withInsertSoftBreak: EditorPlugin = (editor, config) => {
   editor.insertSoftBreak = () => {
     const { selection } = editor;
     if (selection && Range.isCollapsed(selection)) {
-      const [match] = Editor.nodes(editor, {
+      const [match] = editor.nodes({
         match: (n) => !Editor.isEditor(n) && Element.isElement(n),
         mode: 'lowest',
       });

--- a/packages/core/src/plugins/withOriginalNormalizeNode.ts
+++ b/packages/core/src/plugins/withOriginalNormalizeNode.ts
@@ -1,4 +1,4 @@
-import { Element, Transforms } from 'slate';
+import { Element } from 'slate';
 import { EditorPlugin } from '.';
 
 export const withOriginalNormalizeNode: EditorPlugin = (editor, config) => {
@@ -9,8 +9,7 @@ export const withOriginalNormalizeNode: EditorPlugin = (editor, config) => {
     const [node, path] = entry;
     if (editor.children.length === 0) {
       const { defaultElement } = config;
-      Transforms.insertNodes(
-        editor,
+      editor.insertNodes(
         {
           type: defaultElement.type,
           children: defaultElement.editable.defaultValue,

--- a/packages/core/src/toolbar/index.tsx
+++ b/packages/core/src/toolbar/index.tsx
@@ -92,7 +92,7 @@ export const Toolbar: React.FC<ToolbarProps> = () => {
         !isFocused ||
         !selection ||
         Range.isCollapsed(selection) ||
-        Editor.string(editor, selection) === ''
+        editor.string(selection) === ''
       ) {
         return false;
       }

--- a/packages/core/src/toolmenu/index.tsx
+++ b/packages/core/src/toolmenu/index.tsx
@@ -1,5 +1,5 @@
 import { useCallback } from 'react';
-import { Node, Path, Transforms } from 'slate';
+import { Node, Path } from 'slate';
 import { useSlate } from 'slate-react';
 import { CopyIcon } from '../components/icons/copy';
 import { DustboxIcon } from '../components/icons/dustbox';
@@ -13,7 +13,7 @@ export const Toolmenu: React.FC<ToolmenuProps> = ({ path, onDone }) => {
   const editor = useSlate();
 
   const handleDeleteClick = useCallback(() => {
-    Transforms.removeNodes(editor, {
+    editor.removeNodes({
       at: path,
     });
     onDone();
@@ -23,7 +23,7 @@ export const Toolmenu: React.FC<ToolmenuProps> = ({ path, onDone }) => {
     const node = Node.get(editor, path);
     // TODO: There seems to be no API for copying. Replace this workaround if any found.
     const copiedNode = JSON.parse(JSON.stringify(node));
-    Transforms.insertNodes(editor, copiedNode, {
+    editor.insertNodes(copiedNode, {
       at: Path.next(path),
     });
     onDone();
@@ -34,7 +34,11 @@ export const Toolmenu: React.FC<ToolmenuProps> = ({ path, onDone }) => {
       <div>
         <ul className={styles.list}>
           <li>
-            <button type="button" className={styles.button} onClick={handleDeleteClick}>
+            <button
+              type="button"
+              className={styles.button}
+              onClick={handleDeleteClick}
+            >
               <div className={styles.buttonBG} />
               <div className={styles.buttonContainer}>
                 <div className={styles.buttonIcon}>
@@ -45,7 +49,11 @@ export const Toolmenu: React.FC<ToolmenuProps> = ({ path, onDone }) => {
             </button>
           </li>
           <li>
-            <button type="button" className={styles.button} onClick={handleCopyClick}>
+            <button
+              type="button"
+              className={styles.button}
+              onClick={handleCopyClick}
+            >
               <div className={styles.buttonBG} />
               <div className={styles.buttonContainer}>
                 <div className={styles.buttonIcon}>

--- a/packages/element-list/src/list/index.ts
+++ b/packages/element-list/src/list/index.ts
@@ -24,7 +24,7 @@ const element: Element<Attributes> = {
             },
           ],
         });
-        helpers.Transforms.removeNodes(editor, {
+        editor.removeNodes({
           at: childPath,
         });
         isNormalized = true;

--- a/packages/element-list/src/ordered/index.ts
+++ b/packages/element-list/src/ordered/index.ts
@@ -24,7 +24,7 @@ const element: Element<Attributes> = {
             },
           ],
         });
-        helpers.Transforms.removeNodes(editor, {
+        editor.removeNodes({
           at: childPath,
         });
         isNormalized = true;

--- a/packages/element-list/src/todo/index.ts
+++ b/packages/element-list/src/todo/index.ts
@@ -27,7 +27,7 @@ const element: Element<Attributes> = {
             },
           ],
         });
-        helpers.Transforms.removeNodes(editor, {
+        editor.removeNodes({
           at: childPath,
         });
         isNormalized = true;

--- a/packages/element-note/src/body/index.ts
+++ b/packages/element-note/src/body/index.ts
@@ -8,7 +8,7 @@ const element: Element<Attributes> = {
   attributes,
   editable,
   insertBreak: (editor, entry, config) => {
-    const { Path, Transforms, pathHelpers } = helpers;
+    const { Path, pathHelpers } = helpers;
     const [_, path] = entry;
 
     const rootParentPath = pathHelpers.getRootAncestorPath(path);
@@ -16,8 +16,7 @@ const element: Element<Attributes> = {
 
     const { defaultElement } = config;
 
-    Transforms.insertNodes(
-      editor,
+    editor.insertNodes(
       {
         type: defaultElement.type,
         children: defaultElement.editable.defaultValue,
@@ -28,7 +27,7 @@ const element: Element<Attributes> = {
     return true;
   },
   insertSoftBreak: (editor, entry) => {
-    const { Path, Transforms } = helpers;
+    const { Path } = helpers;
     const [_, path] = entry;
     const next = Path.next(path);
 
@@ -42,8 +41,8 @@ const element: Element<Attributes> = {
       ],
     };
 
-    Transforms.insertNodes(editor, element, { at: next });
-    Transforms.select(editor, next);
+    editor.insertNodes(element, { at: next });
+    editor.select(next);
     return true;
   },
 };

--- a/packages/element-quote/src/editable/index.tsx
+++ b/packages/element-quote/src/editable/index.tsx
@@ -11,8 +11,7 @@ const editable: Element<Attributes>['editable'] = {
     const handleCiteChange = useCallback(
       (e: ChangeEvent<HTMLInputElement>) => {
         const { value } = e.currentTarget;
-        helpers.Transforms.setNodes(
-          props.editor,
+        props.editor.setNodes(
           {
             attributes: {
               cite: value,

--- a/packages/element-toggle/src/container/index.ts
+++ b/packages/element-toggle/src/container/index.ts
@@ -14,7 +14,10 @@ const element: Element<Attributes> = {
     let isNormalized: boolean = false;
     const [node, path] = entry;
     for (const [child, childPath] of helpers.Node.children(editor, path)) {
-      if (!helpers.Element.isElement(child) || (child.type !== 'toggle-head' && child.type !== 'toggle-body')) {
+      if (
+        !helpers.Element.isElement(child) ||
+        (child.type !== 'toggle-head' && child.type !== 'toggle-body')
+      ) {
         helpers.logger.warn({
           messages: [
             'Element removed.',
@@ -24,7 +27,7 @@ const element: Element<Attributes> = {
             },
           ],
         });
-        helpers.Transforms.removeNodes(editor, {
+        editor.removeNodes({
           at: childPath,
         });
         isNormalized = true;

--- a/packages/element-toggle/src/head/editable/index.tsx
+++ b/packages/element-toggle/src/head/editable/index.tsx
@@ -21,8 +21,7 @@ const editable: Element<Attributes>['editable'] = {
     const parentElement = useContext(ContainerContext);
 
     const handleCtrlClick = useCallback(() => {
-      helpers.Transforms.setNodes(
-        props.editor,
+      props.editor.setNodes(
         {
           attributes: {
             isOpen: !parentElement.attributes?.isOpen,

--- a/packages/text-emoji/src/editable/index.tsx
+++ b/packages/text-emoji/src/editable/index.tsx
@@ -17,7 +17,7 @@ const editable: Text<Attributes>['editable'] = {
 
     const createInsertText = useCallback(() => {
       return (emojiNative: string) => {
-        helpers.Editor.insertText(props.editor, emojiNative);
+        props.editor.insertText(emojiNative);
       };
     }, []);
 

--- a/packages/text-format/src/toolbar/index.tsx
+++ b/packages/text-format/src/toolbar/index.tsx
@@ -59,8 +59,7 @@ const toolbar: Text<Attributes>['toolbar'] = {
       (event: React.MouseEvent<HTMLButtonElement>) => {
         event.stopPropagation();
         if (href !== undefined && isUrl(href)) {
-          helpers.Transforms.setNodes(
-            editor,
+          editor.setNodes(
             {
               attributes: {
                 href,


### PR DESCRIPTION
## Summary
- remove transform and editor helpers.

## Reference(s)

- slate release note
- [link](https://github.com/ianstormtaylor/slate/releases?page=1)
