### PR TITLE
feat: update deletebackward action✨

### DIFF
--- a/examples/nextjs/package.json
+++ b/examples/nextjs/package.json
@@ -2,7 +2,7 @@
   "name": "@bento-editor/example-nextjs",
   "version": "0.2.2",
   "scripts": {
-    "dev": "next dev -p",
+    "dev": "next dev",
     "build": "next build"
   },
   "dependencies": {

--- a/examples/nextjs/package.json
+++ b/examples/nextjs/package.json
@@ -2,7 +2,7 @@
   "name": "@bento-editor/example-nextjs",
   "version": "0.2.2",
   "scripts": {
-    "dev": "next dev",
+    "dev": "next dev -p 9999",
     "build": "next build"
   },
   "dependencies": {

--- a/examples/nextjs/package.json
+++ b/examples/nextjs/package.json
@@ -2,7 +2,7 @@
   "name": "@bento-editor/example-nextjs",
   "version": "0.2.2",
   "scripts": {
-    "dev": "next dev -p 9999",
+    "dev": "next dev -p",
     "build": "next build"
   },
   "dependencies": {

--- a/packages/core/src/editor/index.tsx
+++ b/packages/core/src/editor/index.tsx
@@ -5,6 +5,7 @@ import { Slate, withReact, ReactEditor } from 'slate-react';
 import { Config, CustomElement } from '../config';
 import { Editable } from '../editable';
 import { helpers } from '../helpers';
+import { withDeleteBackward } from '../plugins/withDeleteBackward';
 import { withInsertBreak } from '../plugins/withInsertBreak';
 import { withInsertSoftBreak } from '../plugins/withInsertSoftBreak';
 import { withOriginalIsVoid } from '../plugins/withOriginalIsVoid';
@@ -55,6 +56,7 @@ export const Editor: React.FC<EditorProps> = ({
       withInsertSoftBreak,
       withOriginalIsVoid,
       withOriginalNormalizeNode,
+      withDeleteBackward,
     ].reduce((editor, plugin) => plugin(editor, config), baseEditor);
 
     return editor;

--- a/packages/core/src/plugins/withDeleteBackward.ts
+++ b/packages/core/src/plugins/withDeleteBackward.ts
@@ -1,0 +1,28 @@
+import { Editor, Element, Node, Text } from 'slate';
+import { EditorPlugin } from '.';
+
+export const withDeleteBackward: EditorPlugin = (editor) => {
+  const originalDeleteBackward = editor.deleteBackward;
+
+  editor.deleteBackward = (unit) => {
+    const { selection } = editor;
+    if (selection && editor.isStart(selection.anchor, selection)) {
+      // 前のnodeのtypeを使用するように変更
+      let previousNode: Node;
+      const previousPoint = editor.before(selection);
+      if (previousPoint) {
+        [previousNode] = editor.node(previousPoint);
+        if (previousNode && !Editor.isEditor(previousNode)) {
+          if (Text.isText(previousNode)) {
+            [previousNode] = editor.parent(previousPoint);
+          }
+          if (Element.isElement(previousNode)) {
+            editor.setNodes({ type: previousNode.type });
+          }
+        }
+      }
+    }
+    originalDeleteBackward(unit);
+  };
+  return editor;
+};

--- a/packages/core/src/plugins/withDeleteBackward.ts
+++ b/packages/core/src/plugins/withDeleteBackward.ts
@@ -1,4 +1,4 @@
-import { Editor, Element, Node, Text } from 'slate';
+import { Element, Text } from 'slate';
 import { EditorPlugin } from '.';
 
 export const withDeleteBackward: EditorPlugin = (editor) => {
@@ -7,17 +7,13 @@ export const withDeleteBackward: EditorPlugin = (editor) => {
   editor.deleteBackward = (unit) => {
     const { selection } = editor;
     if (selection && editor.isStart(selection.anchor, selection)) {
-      // 前のnodeのtypeを使用するように変更
-      let previousNode: Node;
       const previousPoint = editor.before(selection);
       if (previousPoint) {
-        [previousNode] = editor.node(previousPoint);
-        if (previousNode && !Editor.isEditor(previousNode)) {
-          if (Text.isText(previousNode)) {
-            [previousNode] = editor.parent(previousPoint);
-          }
-          if (Element.isElement(previousNode)) {
-            editor.setNodes({ type: previousNode.type });
+        // 前のnodeのtypeを使用するように変更
+        if (Text.isText(editor.node(previousPoint)[0])) {
+          const parent = editor.parent(previousPoint)[0];
+          if (Element.isElement(parent)) {
+            editor.setNodes({ type: parent.type });
           }
         }
       }


### PR DESCRIPTION
## Summary
|Before|After|
|---|---|
|![2023-05-19 17 37 33](https://github.com/cam-inc/bento/assets/22766828/ccd2ce93-034d-4c20-8ef2-bc457b913a26)|![2023-05-19 17 36 32](https://github.com/cam-inc/bento/assets/22766828/e1efc757-2177-4bb8-9cd9-65e9c67896ac)|
```
(Heading 1)
hoge(paragraph)
```
上記のような状況において、2個めのelementの先頭にカーソルを合わせて文字を削除すると、Heading 1が消えてしまい後ろのparagraphになってしまっていた。
notionに挙動を合わせたいので先頭で削除を押した際に前回のelementのtypeを使用するようにしました
