### PR TITLE
style: add shadow to toolbar and toolmenu :lipstick:

### DIFF
--- a/packages/core/src/toolbar/index.css.ts
+++ b/packages/core/src/toolbar/index.css.ts
@@ -12,6 +12,7 @@ export const styles = {
         borderRadius: themeVars.radius.medium,
         border: `1px solid ${themeVars.color.surfaceOnSlight}`,
         overflow: 'hidden',
+        boxShadow: themeVars.boxShadow.level['1'],
       },
     },
   }),

--- a/packages/core/src/toolmenu/index.css.tsx
+++ b/packages/core/src/toolmenu/index.css.tsx
@@ -12,8 +12,8 @@ const root = style({
       border: `1px solid ${themeVars.color.surfaceOnSlight}`,
       overflow: 'hidden',
       boxShadow: themeVars.boxShadow.level['1'],
-    }
-  }
+    },
+  },
 });
 
 const button = style({
@@ -28,7 +28,7 @@ const button = style({
       padding: `${themeVars.space['2']} ${themeVars.space['3']}`,
       position: 'relative',
     },
-  }
+  },
 });
 
 const buttonBG = style({
@@ -44,7 +44,7 @@ const buttonBG = style({
       bottom: 0,
       left: 0,
     },
-  }
+  },
 });
 
 const buttonContainer = style({
@@ -55,8 +55,8 @@ const buttonContainer = style({
       alignItems: 'center',
       justifyContent: 'flex-start',
       gap: themeVars.space['3'],
-    }
-  }
+    },
+  },
 });
 
 const buttonIcon = style({
@@ -71,8 +71,8 @@ const buttonIcon = style({
       display: 'flex',
       alignItems: 'center',
       justifyContent: 'center',
-    }
-  }
+    },
+  },
 });
 
 const buttonTitle = style({
@@ -80,8 +80,8 @@ const buttonTitle = style({
     [`${editorStyles.root} &`]: {
       color: themeVars.color.surfaceOn,
       fontSize: themeVars.fontSize.label.medium,
-    }
-  }
+    },
+  },
 });
 
 const list = style({
@@ -90,8 +90,8 @@ const list = style({
       listStyle: 'none',
       margin: 0,
       padding: 0,
-    }
-  }
+    },
+  },
 });
 
 export const styles = {
@@ -101,5 +101,5 @@ export const styles = {
   buttonContainer,
   buttonIcon,
   buttonTitle,
-  list
+  list,
 };

--- a/packages/core/src/toolmenu/index.css.tsx
+++ b/packages/core/src/toolmenu/index.css.tsx
@@ -11,6 +11,7 @@ const root = style({
       borderRadius: themeVars.radius.medium,
       border: `1px solid ${themeVars.color.surfaceOnSlight}`,
       overflow: 'hidden',
+      boxShadow: themeVars.boxShadow.level['1'],
     }
   }
 });


### PR DESCRIPTION
ツールバーとツールメニューに影をつけました。

変更部分のUI
<img width="619" alt="スクリーンショット 2023-05-23 午後5 34 47" src="https://github.com/cam-inc/bento/assets/74893779/e073678c-f09f-4a32-bd3e-238a2cedd5d4">

<img width="396" alt="スクリーンショット 2023-05-23 午後5 38 08" src="https://github.com/cam-inc/bento/assets/74893779/c95b6e6e-abdc-4990-9a3d-864f27acbf14">
