### PR TITLE
Set types in exports field

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "bento-editor",
-  "version": "0.3.2",
+  "version": "0.3.3",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "bento-editor",
-      "version": "0.3.2",
+      "version": "0.3.3",
       "license": "MIT",
       "workspaces": [
         "apps/*",
@@ -29,7 +29,7 @@
     },
     "apps/website": {
       "name": "@bento-editor/website",
-      "version": "0.3.2",
+      "version": "0.3.3",
       "dependencies": {
         "@docusaurus/core": "3.1.0",
         "@docusaurus/preset-classic": "3.1.0",
@@ -60,7 +60,7 @@
     },
     "examples/nextjs": {
       "name": "@bento-editor/example-nextjs",
-      "version": "0.3.2",
+      "version": "0.3.3",
       "dependencies": {
         "@bento-editor/core": "*",
         "@bento-editor/element-callout": "*",
@@ -158,7 +158,7 @@
     },
     "examples/react": {
       "name": "@bento-editor/example-react",
-      "version": "0.3.2",
+      "version": "0.3.3",
       "dependencies": {
         "@bento-editor/core": "*",
         "@bento-editor/element-callout": "*",
@@ -21179,7 +21179,7 @@
     },
     "packages/core": {
       "name": "@bento-editor/core",
-      "version": "0.3.2",
+      "version": "0.3.3",
       "license": "MIT",
       "dependencies": {
         "@rmwc/switch": "^8.0.1",
@@ -21228,7 +21228,7 @@
     },
     "packages/element-callout": {
       "name": "@bento-editor/element-callout",
-      "version": "0.3.2",
+      "version": "0.3.3",
       "license": "MIT",
       "devDependencies": {
         "@bento-editor/jest-presets": "*",
@@ -21240,13 +21240,13 @@
         "vite": "^3.1.8"
       },
       "peerDependencies": {
-        "@bento-editor/core": "0.3.2",
+        "@bento-editor/core": "0.3.3",
         "@vanilla-extract/css": "^1.7.2"
       }
     },
     "packages/element-divider": {
       "name": "@bento-editor/element-divider",
-      "version": "0.3.2",
+      "version": "0.3.3",
       "license": "MIT",
       "devDependencies": {
         "@bento-editor/jest-presets": "*",
@@ -21258,7 +21258,7 @@
         "vite": "^3.1.8"
       },
       "peerDependencies": {
-        "@bento-editor/core": "0.3.2"
+        "@bento-editor/core": "0.3.3"
       }
     },
     "packages/element-embed": {
@@ -21282,7 +21282,7 @@
     },
     "packages/element-heading": {
       "name": "@bento-editor/element-heading",
-      "version": "0.3.2",
+      "version": "0.3.3",
       "license": "MIT",
       "devDependencies": {
         "@bento-editor/jest-presets": "*",
@@ -21294,12 +21294,12 @@
         "vite": "^3.1.8"
       },
       "peerDependencies": {
-        "@bento-editor/core": "0.3.2"
+        "@bento-editor/core": "0.3.3"
       }
     },
     "packages/element-link": {
       "name": "@bento-editor/element-link",
-      "version": "0.3.2",
+      "version": "0.3.3",
       "license": "MIT",
       "devDependencies": {
         "@bento-editor/jest-presets": "*",
@@ -21311,13 +21311,13 @@
         "vite": "^3.1.8"
       },
       "peerDependencies": {
-        "@bento-editor/core": "0.3.2",
+        "@bento-editor/core": "0.3.3",
         "@vanilla-extract/css": "^1.7.2"
       }
     },
     "packages/element-list": {
       "name": "@bento-editor/element-list",
-      "version": "0.3.2",
+      "version": "0.3.3",
       "license": "MIT",
       "devDependencies": {
         "@bento-editor/jest-presets": "*",
@@ -21329,13 +21329,13 @@
         "vite": "^3.1.8"
       },
       "peerDependencies": {
-        "@bento-editor/core": "0.3.2",
+        "@bento-editor/core": "0.3.3",
         "@vanilla-extract/css": "^1.7.2"
       }
     },
     "packages/element-note": {
       "name": "@bento-editor/element-note",
-      "version": "0.3.2",
+      "version": "0.3.3",
       "license": "MIT",
       "devDependencies": {
         "@bento-editor/jest-presets": "*",
@@ -21347,13 +21347,13 @@
         "vite": "^3.1.8"
       },
       "peerDependencies": {
-        "@bento-editor/core": "0.3.2",
+        "@bento-editor/core": "0.3.3",
         "@vanilla-extract/css": "^1.7.2"
       }
     },
     "packages/element-paragraph": {
       "name": "@bento-editor/element-paragraph",
-      "version": "0.3.2",
+      "version": "0.3.3",
       "license": "MIT",
       "devDependencies": {
         "@bento-editor/jest-presets": "*",
@@ -21365,12 +21365,12 @@
         "vite": "^3.1.8"
       },
       "peerDependencies": {
-        "@bento-editor/core": "0.3.2"
+        "@bento-editor/core": "0.3.3"
       }
     },
     "packages/element-quote": {
       "name": "@bento-editor/element-quote",
-      "version": "0.3.2",
+      "version": "0.3.3",
       "license": "MIT",
       "devDependencies": {
         "@bento-editor/jest-presets": "*",
@@ -21382,12 +21382,12 @@
         "vite": "^3.1.8"
       },
       "peerDependencies": {
-        "@bento-editor/core": "0.3.2"
+        "@bento-editor/core": "0.3.3"
       }
     },
     "packages/element-toggle": {
       "name": "@bento-editor/element-toggle",
-      "version": "0.3.2",
+      "version": "0.3.3",
       "license": "MIT",
       "devDependencies": {
         "@bento-editor/jest-presets": "*",
@@ -21399,7 +21399,7 @@
         "vite": "^3.1.8"
       },
       "peerDependencies": {
-        "@bento-editor/core": "0.3.2",
+        "@bento-editor/core": "0.3.3",
         "@vanilla-extract/css": "^1.7.2"
       }
     },
@@ -21525,7 +21525,7 @@
     },
     "packages/text-emoji": {
       "name": "@bento-editor/text-emoji",
-      "version": "0.3.2",
+      "version": "0.3.3",
       "license": "MIT",
       "dependencies": {
         "@emoji-mart/data": "^1.0.6",
@@ -21541,13 +21541,13 @@
         "vite": "^3.1.0"
       },
       "peerDependencies": {
-        "@bento-editor/core": "0.3.2",
+        "@bento-editor/core": "0.3.3",
         "@vanilla-extract/css": "^1.7.2"
       }
     },
     "packages/text-format": {
       "name": "@bento-editor/text-format",
-      "version": "0.3.2",
+      "version": "0.3.3",
       "license": "MIT",
       "dependencies": {
         "react-colorful": "^5.6.1"
@@ -21562,7 +21562,7 @@
         "vite": "^3.1.8"
       },
       "peerDependencies": {
-        "@bento-editor/core": "0.3.2",
+        "@bento-editor/core": "0.3.3",
         "@vanilla-extract/css": "^1.7.2"
       }
     }

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -7,6 +7,7 @@
   "types": "./dist/types/index.d.ts",
   "exports": {
     ".": {
+      "types": "./dist/types/index.d.ts",
       "import": "./dist/es.js",
       "require": "./dist/cjs.js"
     },

--- a/packages/element-callout/package.json
+++ b/packages/element-callout/package.json
@@ -5,6 +5,7 @@
   "types": "./dist/types/index.d.ts",
   "exports": {
     ".": {
+      "types": "./dist/types/index.d.ts",
       "import": "./dist/es.js",
       "require": "./dist/cjs.js"
     },

--- a/packages/element-divider/package.json
+++ b/packages/element-divider/package.json
@@ -5,6 +5,7 @@
   "types": "./dist/types/index.d.ts",
   "exports": {
     ".": {
+      "types": "./dist/types/index.d.ts",
       "import": "./dist/es.js",
       "require": "./dist/cjs.js"
     },

--- a/packages/element-heading/package.json
+++ b/packages/element-heading/package.json
@@ -5,6 +5,7 @@
   "types": "./dist/types/index.d.ts",
   "exports": {
     ".": {
+      "types": "./dist/types/index.d.ts",
       "import": "./dist/es.js",
       "require": "./dist/cjs.js"
     },

--- a/packages/element-link/package.json
+++ b/packages/element-link/package.json
@@ -5,6 +5,7 @@
   "types": "./dist/types/index.d.ts",
   "exports": {
     ".": {
+      "types": "./dist/types/index.d.ts",
       "import": "./dist/es.js",
       "require": "./dist/cjs.js"
     },

--- a/packages/element-list/package.json
+++ b/packages/element-list/package.json
@@ -5,6 +5,7 @@
   "types": "./dist/types/index.d.ts",
   "exports": {
     ".": {
+      "types": "./dist/types/index.d.ts",
       "import": "./dist/es.js",
       "require": "./dist/cjs.js"
     },

--- a/packages/element-note/package.json
+++ b/packages/element-note/package.json
@@ -5,6 +5,7 @@
   "types": "./dist/types/index.d.ts",
   "exports": {
     ".": {
+      "types": "./dist/types/index.d.ts",
       "import": "./dist/es.js",
       "require": "./dist/cjs.js"
     },

--- a/packages/element-paragraph/package.json
+++ b/packages/element-paragraph/package.json
@@ -5,6 +5,7 @@
   "types": "./dist/types/index.d.ts",
   "exports": {
     ".": {
+      "types": "./dist/types/index.d.ts",
       "import": "./dist/es.js",
       "require": "./dist/cjs.js"
     },

--- a/packages/element-quote/package.json
+++ b/packages/element-quote/package.json
@@ -5,6 +5,7 @@
   "types": "./dist/types/index.d.ts",
   "exports": {
     ".": {
+      "types": "./dist/types/index.d.ts",
       "import": "./dist/es.js",
       "require": "./dist/cjs.js"
     },

--- a/packages/element-toggle/package.json
+++ b/packages/element-toggle/package.json
@@ -5,6 +5,7 @@
   "types": "./dist/types/index.d.ts",
   "exports": {
     ".": {
+      "types": "./dist/types/index.d.ts",
       "import": "./dist/es.js",
       "require": "./dist/cjs.js"
     },

--- a/packages/text-emoji/package.json
+++ b/packages/text-emoji/package.json
@@ -5,6 +5,7 @@
   "types": "./dist/types/index.d.ts",
   "exports": {
     ".": {
+      "types": "./dist/types/index.d.ts",
       "import": "./dist/es.js",
       "require": "./dist/cjs.js"
     },

--- a/packages/text-format/package.json
+++ b/packages/text-format/package.json
@@ -5,6 +5,7 @@
   "types": "./dist/types/index.d.ts",
   "exports": {
     ".": {
+      "types": "./dist/types/index.d.ts",
       "import": "./dist/es.js",
       "require": "./dist/cjs.js"
     },


### PR DESCRIPTION
## Summary


Currently, if you are using typescript and set `"moduleResolution": "Bundler"`, no type information is provided.
To fix this problem, add types to the Exports Field.
